### PR TITLE
WI-1417 quito validacion para el flag vtex-parents

### DIFF
--- a/src/Stages/HistoricalProducts/VTEXWoowUpHistoricalProductMapper.php
+++ b/src/Stages/HistoricalProducts/VTEXWoowUpHistoricalProductMapper.php
@@ -15,7 +15,7 @@ class VTEXWoowUpHistoricalProductMapper extends StageMapperForParentProducts
     {
         $this->vtexConnector = $vtexConnector;
         $this->stockEqualsZero = $stockEqualsZero;
-        $this->onlyMapsParentProducts = $this->mapsParentProducts($this->vtexConnector->getAppId(), $this->vtexConnector->getFeatures());
+        $this->onlyMapsParentProducts = $this->mapsParentProducts($this->vtexConnector->getAppId());
 
         $productsLog = "Mapping " . ($this->onlyMapsParentProducts ? "Parent" : "Child") . "Products";
         $this->vtexConnector->_logger->info($productsLog);

--- a/src/Stages/Orders/VTEXWoowUpOrderMapper.php
+++ b/src/Stages/Orders/VTEXWoowUpOrderMapper.php
@@ -22,7 +22,7 @@ class VTEXWoowUpOrderMapper extends StageMapperForParentProducts
         $this->vtexConnector = $vtexConnector;
         $this->importing     = $importing;
         $this->logger        = $logger;
-        $this->onlyMapsParentProducts = $this->mapsParentProducts($this->vtexConnector->getAppId(), $this->vtexConnector->getFeatures());
+        $this->onlyMapsParentProducts = $this->mapsParentProducts($this->vtexConnector->getAppId());
 
         $productsLog = "Mapping " . ($this->onlyMapsParentProducts ? "Parent" : "Child") . "Products";
         $this->logger->info($productsLog);

--- a/src/Stages/Products/VTEXWoowUpProductMapper.php
+++ b/src/Stages/Products/VTEXWoowUpProductMapper.php
@@ -14,7 +14,7 @@ abstract class VTEXWoowUpProductMapper extends StageMapperForParentProducts
     public function __construct($vtexConnector)
     {
         $this->vtexConnector = $vtexConnector;
-        $this->onlyMapsParentProducts = $this->mapsParentProducts($this->vtexConnector->getAppId(), $this->vtexConnector->getFeatures());
+        $this->onlyMapsParentProducts = $this->mapsParentProducts($this->vtexConnector->getAppId());
 
         $productsLog = "Mapping " . ($this->onlyMapsParentProducts ? "Parent" : "Child") . "Products";
         $this->vtexConnector->_logger->info($productsLog);

--- a/src/Stages/StageMapperForParentProducts.php
+++ b/src/Stages/StageMapperForParentProducts.php
@@ -5,13 +5,9 @@ use League\Pipeline\StageInterface;
 
 abstract class StageMapperForParentProducts implements StageInterface
 {
-    protected function mapsParentProducts($appId, $features)
+    protected function mapsParentProducts($appId)
     {
-        $mapsParentProducts = false;
-        if(in_array('vtex-parents', $features)){
-            $parentAccounts = explode(',', env('VTEX_PARENTS'));
-            $mapsParentProducts = in_array(strval($appId), $parentAccounts);
-        }
-        return $mapsParentProducts;
+        $parentAccounts = explode(',', env('VTEX_PARENTS'));
+        return in_array(strval($appId), $parentAccounts);
     }
 }


### PR DESCRIPTION
[WI-1417](https://woowup.atlassian.net/jira/software/projects/WI/boards/7?selectedIssue=WI-1417)

Se necesita quitar el if que valida si el comando tiene el flag -F vtex_parents. Con esto, solo descargará productos padres, si solo si el id de cuenta se encuentra en el .env.vtex.


En la tercera linea ya indica que tomará productos padres
![Screenshot from 2023-01-24 12-21-04](https://user-images.githubusercontent.com/117051473/214334468-e8cb8995-5b59-4f05-b8d7-0615cd22f849.png)
