### PR TITLE
WI-1417 quito validacion para el flag vtex-parents

### DIFF
--- a/src/VTEXWoowUp.php
+++ b/src/VTEXWoowUp.php
@@ -333,7 +333,7 @@ class VTEXWoowUp
         $this->logger->info("Importing products");
 
         if (!$this->mapStage) {
-            if ($this->mapsParentProducts($this->vtexConnector->getAppId(), $this->vtexConnector->getFeatures())){
+            if ($this->mapsParentProducts($this->vtexConnector->getAppId())){
                 $this->setMapStage(new VTEXWoowUpProductWithoutChildrenMapper($this->vtexConnector));
             } else {
                 $this->setMapStage(new VTEXWoowUpProductWithChildrenMapper($this->vtexConnector));
@@ -415,14 +415,10 @@ class VTEXWoowUp
     }
 
 
-    protected function mapsParentProducts($appId, $features)
+    protected function mapsParentProducts($appId)
     {
-        $mapsParentProducts = false;
-        if(in_array('vtex-parents', $features)){
-            $parentAccounts = explode(',', env('VTEX_PARENTS'));
-            $mapsParentProducts = in_array(strval($appId), $parentAccounts);
-        }
-        return $mapsParentProducts;
+        $parentAccounts = explode(',', env('VTEX_PARENTS'));
+        return in_array(strval($appId), $parentAccounts);
     }
 
     public function getConnector()


### PR DESCRIPTION
[WI-1417](https://woowup.atlassian.net/jira/software/projects/WI/boards/7?selectedIssue=WI-1417)

Se necesita quitar el if que valida si el comando tiene el flag -F vtex_parents. Con esto, solo descargará productos padres, si solo si el id de cuenta se encuentra en el .env.vtex.

Los sku son de productos padres
![Screenshot from 2023-01-24 14-15-52](https://user-images.githubusercontent.com/117051473/214362028-2b74bbc0-6ce8-4189-8a8d-8f5ac63d8fc0.png)

![Screenshot from 2023-01-24 14-14-56](https://user-images.githubusercontent.com/117051473/214362209-5dc596f1-604f-4780-8796-8e88e8cdd9ce.png)

