### PR TITLE
WI-1738 Cambio precio de items por item disponible

### DIFF
--- a/src/Stages/Products/VTEXWoowUpProductMapper.php
+++ b/src/Stages/Products/VTEXWoowUpProductMapper.php
@@ -54,8 +54,9 @@ abstract class VTEXWoowUpProductMapper implements StageInterface
      */
     protected function getItemPrice($vtexItem)
     {
-        if (isset($vtexItem->sellers) && isset($vtexItem->sellers[0]) && isset($vtexItem->sellers[0]->commertialOffer) && isset($vtexItem->sellers[0]->commertialOffer->Price)) {
-            return $vtexItem->sellers[0]->commertialOffer->Price;
+        $itemPrize = $vtexItem->sellers[0]->commertialOffer->Price ?? null;
+        if ($itemPrize) {
+            return $itemPrize;
         } else {
             $prices = $this->vtexConnector->searchItemPrices($vtexItem->itemId);
             return $prices->basePrice;
@@ -69,8 +70,9 @@ abstract class VTEXWoowUpProductMapper implements StageInterface
      */
     protected function getItemListPrice($vtexItem)
     {
-        if (isset($vtexItem->sellers) && isset($vtexItem->sellers[0]) && isset($vtexItem->sellers[0]->commertialOffer) && isset($vtexItem->sellers[0]->commertialOffer->ListPrice)) {
-            return $vtexItem->sellers[0]->commertialOffer->ListPrice;
+        $itemPrize = $vtexItem->sellers[0]->commertialOffer->ListPrice ?? null;
+        if ($itemPrize) {
+            return $itemPrize;
         } else {
             $prices = $this->vtexConnector->searchItemPrices($vtexItem->itemId);
             if (isset($prices->listPrice)) {

--- a/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
+++ b/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
@@ -18,17 +18,18 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
             return null;
         }
 
-        $baseProduct = $vtexBaseProduct->items[0];
+        $firstItem = $vtexBaseProduct->items[0];
+        $availableItem = $this->searchForAvailableProduct($vtexBaseProduct);
 
         $product = [
             'brand'             => $vtexBaseProduct->brand,
             'description'       => $vtexBaseProduct->description,
             'url'               => preg_replace('/https?:\/\/.*\.vtexcommercestable\.com\.br/si', $this->vtexConnector->getStoreUrl(), $vtexBaseProduct->link),
             'release_date'      => $vtexBaseProduct->releaseDate,
-            'image_url'         => $this->getImageUrl($baseProduct),
-            'thumbnail_url'     => $this->getImageUrl($baseProduct),
-            'price'             => $this->getItemListPrice($baseProduct),
-            'offer_price'       => $this->getItemPrice($baseProduct),
+            'image_url'         => $this->getImageUrl($firstItem),
+            'thumbnail_url'     => $this->getImageUrl($firstItem),
+            'price'             => $this->getItemListPrice($availableItem),
+            'offer_price'       => $this->getItemPrice($availableItem),
             'stock'             => $this->getStock($vtexBaseProduct),
             'available'         => true
         ];
@@ -38,8 +39,8 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
             $product['sku']  = $vtexBaseProduct->productReference;
         } else {
             $product['base_name'] = $vtexBaseProduct->productName;
-            $product['name']      = $baseProduct->name;
-            $product['sku']       = $baseProduct->referenceId[0]->Value;
+            $product['name']      = $firstItem->name;
+            $product['sku']       = $firstItem->referenceId[0]->Value;
         }
 
         $categories = $this->vtexConnector->getCategories();
@@ -70,5 +71,16 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
             $stock += $this->getItemStock($vtexProduct);
         }
         return $stock;
+    }
+
+    private function searchForAvailableProduct($vtexBaseProduct) {
+        foreach ($vtexBaseProduct->items as $vtexItem) {
+            $available = $vtexItem->sellers[0]->commertialOffer->IsAvailable ?? false;
+            if ($available) {
+                return $vtexItem;
+            }
+        }
+
+        return $vtexBaseProduct->items[0];
     }
 }

--- a/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
+++ b/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
@@ -3,6 +3,7 @@
 namespace WoowUpConnectors\Stages\Products;
 
 use WoowUpConnectors\Stages\Products\VTEXWoowUpProductMapper;
+use WoowUpConnectors\Stages\VTEXConfig;
 
 class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
 {
@@ -19,7 +20,10 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
         }
 
         $firstItem = $vtexBaseProduct->items[0];
-        $availableItem = $this->searchForAvailableProduct($vtexBaseProduct);
+        $availableItem = $firstItem;
+        if($this->searchesForAvailableProduct()) {
+            $availableItem = $this->searchForAvailableProduct($vtexBaseProduct);
+        }
 
         $product = [
             'brand'             => $vtexBaseProduct->brand,
@@ -82,5 +86,9 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
         }
 
         return $vtexBaseProduct->items[0];
+    }
+
+    private function searchesForAvailableProduct(): bool {
+        return in_array($this->vtexConnector->getAppId(), VTEXConfig::getAvailableProductsAccounts());
     }
 }

--- a/src/Stages/VTEXConfig.php
+++ b/src/Stages/VTEXConfig.php
@@ -19,4 +19,9 @@ class VTEXConfig
     {
         return explode(',', env('TEST_FEATURE_APP_IDS'));
     }
+
+    public static function getAvailableProductsAccounts()
+    {
+        return explode(',', env('SEARCH_FOR_AVAILABLE_PRODUCTS_ACCOUNTS'));
+    }
 }


### PR DESCRIPTION
Hice el cambio para que Vtex tome el precio del primer item disponible, en lugar del primer item.
Se probó con Freeport (vtex:products -f -m -D -a 1490) y Pigmento (vtex:products -f -m -D -a 1547) y funcionó correctamente:
![image](https://github.com/woowup/vtex-woowup-connector/assets/133383075/3b6d0c34-71e9-4ea1-906d-a8e83dbde2c1)

![image](https://github.com/woowup/vtex-woowup-connector/assets/133383075/0aa54f0e-0cdc-4b0f-9c37-f6ea529867ca)

![image](https://github.com/woowup/vtex-woowup-connector/assets/133383075/62465760-8a2f-4d29-84d6-50fdbae23356)
