### PR TITLE
Modifico toma de campo de retiro

### DIFF
--- a/src/Stages/Orders/VTEXWoowUpOrderMapper.php
+++ b/src/Stages/Orders/VTEXWoowUpOrderMapper.php
@@ -87,8 +87,9 @@ class VTEXWoowUpOrderMapper implements StageInterface
             $order['custom_attributes']['tracking_id'] = $vtexOrder->packageAttachment->packages[0]->trackingNumber;
         }
 
-        if (isset($vtexOrder->shippingData) && isset($vtexOrder->shippingData->logisticsInfo) && isset($vtexOrder->shippingData->logisticsInfo[0]) && isset($vtexOrder->shippingData->logisticsInfo[0]->deliveryIds) && isset($vtexOrder->shippingData->logisticsInfo[0]->deliveryIds[0]) && isset($vtexOrder->shippingData->logisticsInfo[0]->deliveryIds[0]->courierName) && !empty($vtexOrder->shippingData->logisticsInfo[0]->deliveryIds[0]->courierName)) {
-            $order['custom_attributes']['tienda_retiro'] = $vtexOrder->shippingData->logisticsInfo[0]->deliveryIds[0]->courierName;
+        $tiendaRetiro = $vtexOrder->shippingData->logisticsInfo[0]->pickupStoreInfo->friendlyName ?? null;
+        if ($tiendaRetiro) {
+            $order['custom_attributes']['tienda_retiro'] = $tiendaRetiro;
         }
 
         if ($this->hasCoupon($vtexOrder)) {


### PR DESCRIPTION
Cambio la toma de tienda de retiro.

Se probó con:
vtex:orders -f -m -D -a 1455
vtex:orders -f -m -D -a 1248

Ejemplo de como queda una venta:
![image](https://github.com/woowup/vtex-woowup-connector/assets/133383075/b537b270-0141-4002-bf00-941f9415fdea)
