### PR TITLE
WI-1926 - fix credit card response

### DIFF
--- a/src/Stages/Orders/WoowUpCCInfoStage.php
+++ b/src/Stages/Orders/WoowUpCCInfoStage.php
@@ -61,6 +61,7 @@ class WoowUpCCInfoStage implements StageInterface
                 continue;
             }
 
+            $result = json_decode($result)->payload;
             $result->type && $payment['type'] = $result->type;
             $result->scheme && $payment['brand'] = $result->scheme;
             $result->bank && $result->bank->name && $payment['bank'] = $result->bank->name;


### PR DESCRIPTION
https://woowup.sentry.io/issues/4395627601/?project=1457092&query=is%3Aunresolved&referrer=issue-stream&stream_index=8

La response del endpoint tarjetas de credito le faltaba el json_decode