### PR TITLE
fix - added clean array on order mapper

### DIFF
--- a/src/Stages/Orders/VTEXWoowUpOrderMapper.php
+++ b/src/Stages/Orders/VTEXWoowUpOrderMapper.php
@@ -108,7 +108,19 @@ class VTEXWoowUpOrderMapper implements StageInterface
             }
         }
 
-        return $order;
+        return $this->cleanArray($order);
+    }
+
+    private function cleanArray($array)
+    {
+        foreach ($array as $key => $value) {
+            if (gettype($value) === 'array') {
+                $array[$key] = $this->cleanArray($value);
+            } elseif ($value === null || $value === '') {
+                unset($array[$key]);
+            }
+        }
+        return $array;
     }
 
     /**


### PR DESCRIPTION
A partir de que la api  de WoowUp no acepta valores null se implemento el clean array en el mapper de orders, lo que hace es unsetear los campos que se seteen con null o vacio. Adjunto capturas de la solucion al problema en la cuenta de ferouch donde el postcode se seteaba como null. Y también adjunto captura de otras cuentas para dejar en evidencia que no rompe en otras cuentas.

Proceso de ordenes con ferouch antes del cleanArray
![imagen](https://github.com/woowup/vtex-woowup-connector/assets/169811485/30c19e8a-d7f8-440e-9704-1403809498b9)


Proceso de ordenes con ferouch despues del cleanArray
![imagen](https://github.com/woowup/vtex-woowup-connector/assets/169811485/f5ddfdcd-af2d-4c5a-8b62-b7d43b84c4a9)


Otras cuentas
Farmacias del pueblo
![imagen](https://github.com/woowup/vtex-woowup-connector/assets/169811485/e398c3d5-5a41-4cb5-abe7-aa2181688c71)

Arredo
![imagen](https://github.com/woowup/vtex-woowup-connector/assets/169811485/5c4d8d90-d5a7-43b8-88da-3e602cb9bbc9)

