### PR TITLE
fix/add-status-code-502-banks-info-error

### DIFF
--- a/src/Stages/Orders/WoowUpCCInfoStage.php
+++ b/src/Stages/Orders/WoowUpCCInfoStage.php
@@ -9,7 +9,13 @@ class WoowUpCCInfoStage implements StageInterface
     const HTTP_NOT_FOUND = 404;
     const HTTP_SERVICE_UNAVAILABLE = 503;
 
-    protected static $httpCodes = [self::HTTP_NOT_FOUND, self::HTTP_SERVICE_UNAVAILABLE];
+    const HTTP_BAD_GATEWAY = 502;
+
+    protected static $httpCodes = [
+        self::HTTP_NOT_FOUND,
+        self::HTTP_SERVICE_UNAVAILABLE,
+        self::HTTP_BAD_GATEWAY
+    ];
 
     protected $woowupClient;
     protected $logger;


### PR DESCRIPTION
Se agrega el status 502 cuando solicitamos la info de bancos y se logea en vez de enviar a sentry
https://woowup.sentry.io/issues/4395627601/?end=2024-03-31T23%3A59%3A59&project=1457092&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&start=2024-03-11T00%3A00%3A00&stream_index=1&utc=true