### PR TITLE
WI-2923 - arrojo exception para errores en precios

### DIFF
--- a/src/Exceptions/VTEXRequestException.php
+++ b/src/Exceptions/VTEXRequestException.php
@@ -9,7 +9,7 @@ class VTEXRequestException extends \Exception
 
     public function __construct($message = '', $code = 0, $endpoint = '', $params = [], $sendToClient = false)
     {
-        parent::__construct("Codigo de Error: $code Mensaje: $message Endpoint $endpoint ");
+        parent::__construct("Codigo de Error: $code Mensaje: $message Endpoint $endpoint ", $code);
         $this->requestParams = $params;
         $this->sendToClient = $sendToClient;
     }

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -699,8 +699,11 @@ class VTEXConnector
             $response = $this->_post("/api/checkout/pvt/orderForms/simulation", [], [], $body);
             $this->_logger->info("Success!");
             return json_decode($response->getBody());
-        } catch (\Exception $e) {
+        } catch (VTEXRequestException $e) {
             $this->_logger->info("Could not get price and stock info for item Id $vtexItemId - Message: {$e->getMessage()}");
+            throw $e;
+        } catch (\Exception $e) {
+            $this->_logger->info("Internal error Could not get price and stock info for item Id $vtexItemId - Message: {$e->getMessage()}");
             return 0;
         }
     }


### PR DESCRIPTION
Se agrega el error code a VTEXRequestException se detectó que siempre es 0
Se arroja la exception cuando hay un error en precios para luego capturar y notificar