### PR TITLE
add sales channel from vtex when configuration value is a valid integer

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -123,40 +123,31 @@ class VTEXConnector
      * Retrieves the name of the sales channel based on the given configuration value.
      *
      * If the configuration value is a valid integer, it fetches the list of sales channels
-     * from the API and returns the corresponding name. If no match is found, it returns
+     * from the VTEX API and returns the corresponding name. If no match is found, it returns
      * the original configuration value.
      *
      * @param mixed $salesChannelFromConfig The sales channel ID or name from the configuration.
      *
      * @return string The sales channel name or the original configuration value if no match is found.
-     * @throws \RuntimeException If an error occurs while fetching the sales channel list from the API.
      */
     private function getSalesChannel($salesChannelFromConfig)
     {
-        // Validate if the provided configuration is an integer
         if (filter_var($salesChannelFromConfig, FILTER_VALIDATE_INT) !== false) {
             try {
-                // Fetch the list of sales channels from the API
                 $response = $this->_get('/api/catalog_system/pvt/saleschannel/list');
                 $body = json_decode($response->getBody(), true);
 
-                // Cast the config value to an integer
-                $salesChannelId = (int) $salesChannelFromConfig;
-
                 // Search for the matching sales channel by ID
                 foreach ($body as $salesChannel) {
-                    if ($salesChannel['Id'] === $salesChannelId) {
+                    if ($salesChannel['Id'] == $salesChannelFromConfig) {
                         return $salesChannel['Name'];
                     }
                 }
             } catch (\Exception $e) {
                 $this->_logger->error("VTEX Error retrieving sales channel list: " . $e->getMessage());
-                return null;
             }
         }
-
-        // Return the original configuration value if it's not an integer or no match is found
-        return (string) $salesChannelFromConfig;
+        return $salesChannelFromConfig;
     }
 
     /**

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -107,16 +107,56 @@ class VTEXConnector
             $this->_appName        = $vtexConfig['appName'];
             $this->_status         = isset($vtexConfig['status']) && $vtexConfig['status'] ? $vtexConfig['status'] : [self::STATUS_INVOICED];
             $this->_storeUrl       = $vtexConfig['storeUrl'];
-            $this->_salesChannel   = isset($vtexConfig['salesChannel']) ? $vtexConfig['salesChannel'] : null;
             $this->_branchName     = isset($vtexConfig['branchName']) ? $vtexConfig['branchName'] : self::DEFAULT_BRANCH_NAME;
             $this->_allowedSellers = isset($vtexConfig['allowedSellers']) ? $vtexConfig['allowedSellers'] : null;
             $this->_syncCategories = isset($vtexConfig['syncCategories']) ? $vtexConfig['syncCategories'] : null;
             $this->_httpClient     = $httpClient;
             $this->features        = $features;
+            $this->_salesChannel   = isset($vtexConfig['salesChannel']) ? $this->getSalesChannel($vtexConfig['salesChannel']) : null;
         } catch (\Exception $e) {
             $this->_logger->error("VTEX Service Error: " . $e->getMessage());
             return null;
         }
+    }
+
+    /**
+     * Retrieves the name of the sales channel based on the given configuration value.
+     *
+     * If the configuration value is a valid integer, it fetches the list of sales channels
+     * from the API and returns the corresponding name. If no match is found, it returns
+     * the original configuration value.
+     *
+     * @param mixed $salesChannelFromConfig The sales channel ID or name from the configuration.
+     *
+     * @return string The sales channel name or the original configuration value if no match is found.
+     * @throws \RuntimeException If an error occurs while fetching the sales channel list from the API.
+     */
+    private function getSalesChannel($salesChannelFromConfig)
+    {
+        // Validate if the provided configuration is an integer
+        if (filter_var($salesChannelFromConfig, FILTER_VALIDATE_INT) !== false) {
+            try {
+                // Fetch the list of sales channels from the API
+                $response = $this->_get('/api/catalog_system/pvt/saleschannel/list');
+                $body = json_decode($response->getBody(), true);
+
+                // Cast the config value to an integer
+                $salesChannelId = (int) $salesChannelFromConfig;
+
+                // Search for the matching sales channel by ID
+                foreach ($body as $salesChannel) {
+                    if ($salesChannel['Id'] === $salesChannelId) {
+                        return $salesChannel['Name'];
+                    }
+                }
+            } catch (\Exception $e) {
+                $this->_logger->error("VTEX Error retrieving sales channel list: " . $e->getMessage());
+                return null;
+            }
+        }
+
+        // Return the original configuration value if it's not an integer or no match is found
+        return (string) $salesChannelFromConfig;
     }
 
     /**


### PR DESCRIPTION
En casos donde la configuracion setea el id del sales channel debemos ir a buscar el nombre del sales channel a la api de vtex y asi poder realizar la busqueda de ventas a traves de ese sales channel.

![imagen](https://github.com/user-attachments/assets/a9f418ba-2569-445e-a986-c472ab057c68)

![imagen](https://github.com/user-attachments/assets/816b7584-3941-4b30-a9d3-615d6d3bc2dc)

Cuando no es un numero devuelve lo que ya venía en la config
![imagen](https://github.com/user-attachments/assets/5d130731-a93b-4622-b243-03f62b057a96)
