### PR TITLE
add function to download inactive products

### DIFF
--- a/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
+++ b/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
@@ -15,6 +15,12 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
 
     protected function buildProducts($vtexBaseProduct)
     {
+        if (isset($vtexBaseProduct->isInactive) && $vtexBaseProduct->isInactive) {
+            yield [
+                'sku' => $vtexBaseProduct->RefId,
+                'stock' => 0
+            ];
+        }
         if (!$this->hasSku($vtexBaseProduct)) {
             return null;
         }

--- a/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
+++ b/src/Stages/Products/VTEXWoowUpProductWithoutChildrenMapper.php
@@ -16,6 +16,7 @@ class VTEXWoowUpProductWithoutChildrenMapper extends VTEXWoowUpProductMapper
     protected function buildProducts($vtexBaseProduct)
     {
         if (isset($vtexBaseProduct->isInactive) && $vtexBaseProduct->isInactive) {
+            if (!isset($vtexBaseProduct->RefId)) return null;
             yield [
                 'sku' => $vtexBaseProduct->RefId,
                 'stock' => 0

--- a/src/Stages/VTEXConfig.php
+++ b/src/Stages/VTEXConfig.php
@@ -20,4 +20,9 @@ class VTEXConfig
         return explode(',', env('TEST_FEATURE_APP_IDS'));
     }
 
+    public static function downloadInactivePorducts($appId): bool
+    {
+        $accounts = explode(',', env('DOWNLOAD_INACTIVE_PRODUCTS'));
+        return in_array(strval($appId), $accounts);
+    }
 }

--- a/src/Stages/VTEXConfig.php
+++ b/src/Stages/VTEXConfig.php
@@ -20,7 +20,7 @@ class VTEXConfig
         return explode(',', env('TEST_FEATURE_APP_IDS'));
     }
 
-    public static function downloadInactivePorducts($appId): bool
+    public static function downloadInactiveProducts($appId): bool
     {
         $accounts = explode(',', env('DOWNLOAD_INACTIVE_PRODUCTS'));
         return in_array(strval($appId), $accounts);

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -403,7 +403,7 @@ class VTEXConnector
 
             $vtexProducts = json_decode($response->getBody());
 
-            if (empty($vtexProducts) && VTEXConfig::downloadInactivePorducts($this->_appId)) {
+            if (empty($vtexProducts) && VTEXConfig::downloadInactiveProducts($this->_appId)) {
                 $vtexProducts = array($this->getProductByProductId($skuId));
                 if (!empty($vtexProducts[0])) {
                     $vtexProducts[0]->isInactive = true;

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -6,6 +6,7 @@ use League\Pipeline\Pipeline;
 use WoowUpConnectors\Exceptions\VTEXException;
 use WoowUpConnectors\Exceptions\VTEXRequestException;
 use Psr;
+use WoowUpConnectors\Stages\VTEXConfig;
 
 class VTEXConnector
 {
@@ -401,6 +402,13 @@ class VTEXConnector
             }
 
             $vtexProducts = json_decode($response->getBody());
+
+            if (empty($vtexProducts) && VTEXConfig::downloadInactivePorducts($this->_appId)) {
+                $vtexProducts = array($this->getProductByProductId($skuId));
+                if (!empty($vtexProducts[0])) {
+                    $vtexProducts[0]->isInactive = true;
+                }
+            }
 
             foreach ($vtexProducts as $vtexBaseProduct) {
                 yield $vtexBaseProduct;


### PR DESCRIPTION
Ticket asociado: https://woowup.atlassian.net/jira/software/projects/WI/boards/7?selectedIssue=WI-3624

con este ejemplo de mensaje del webhook: '{"AppId":1608,"WU_ApiKey":"42f706366463113ef80f980036aca73d02abbb31d4c54552b8fde1e6d8222680","IdSku":"794927","An":"celadasa","IdAffiliate":"WWP","ProductId":794927,"DateModified":"2025-03-27T15:48:07.0531691Z","IsActive":true,"StockModified":false,"PriceModified":false,"HasStockKeepingUnitModified":true,"HasStockKeepingUnitRemovedFromAffiliate":false}'
Primero intenta buscar el producto como lo hacia antes y no lo encuentra
![imagen](https://github.com/user-attachments/assets/ecb29913-7220-4247-b319-167eed167b55)
Luego con el otro endpoint si lo encuentra
![imagen](https://github.com/user-attachments/assets/50a1f533-1d81-4025-9888-70925d41589a)
Y asi lo mapea:
![imagen](https://github.com/user-attachments/assets/dc1a70be-d3f0-47e8-90b8-362b63ec6fd3)
