### PR TITLE
fix download today orders when days from flag is zero

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -811,7 +811,7 @@ class VTEXConnector
     public function getFromAndToDates($fromDate, $toDate, $daysFrom): array
     {
         if ($fromDate === null) {
-            $dateFromTime = $daysFrom ? strtotime("-$daysFrom days") : strtotime(self::DEFAULT_FROM_DATE_DIFFERENCE);
+            $dateFromTime = $daysFrom || $daysFrom == '0' ? strtotime("-$daysFrom days") : strtotime(self::DEFAULT_FROM_DATE_DIFFERENCE);
             $fromDate = date('Y-m-d', $dateFromTime);
         }
 


### PR DESCRIPTION
Debido a que necesitamos para farmaonline mandar solo el día actual, fixeamos que al mandarle days from 0 tome el dia actual y no tome como que esta vacio el flag 
![imagen](https://github.com/user-attachments/assets/15ded172-afc8-4cb4-b975-247af46f06e2)
