### PR TITLE
WI-3979 mejora conectores blacklist clientes

### DIFF
--- a/src/Stages/Customers/VTEXWoowUpCustomerMapper.php
+++ b/src/Stages/Customers/VTEXWoowUpCustomerMapper.php
@@ -112,6 +112,8 @@ class VTEXWoowUpCustomerMapper implements StageInterface
             }
 
             if (isset($customer['email'])) {
+                $isBlacklisted = false;
+
                 foreach (self::BLACKLISTED_EMAIL_PATTERNS as $pattern) {
                     if (stripos($customer['email'], $pattern) !== false) {
                         if (!empty($customer['email'])
@@ -123,24 +125,32 @@ class VTEXWoowUpCustomerMapper implements StageInterface
                         } else {
                             $customer['email'] = self::REPLACEMENT_EMAIL;
                         }
+                        $isBlacklisted = true;
                         break;
                     }
                 }
 
-                foreach (self::WHITELISTED_EMAIL_PATTERNS as $pattern) {
-                    if (stripos($customer['email'], $pattern) !== false) {
+                if (!$isBlacklisted) {
+                    $isWhitelisted = false;
+                    foreach (self::WHITELISTED_EMAIL_PATTERNS as $pattern) {
+                        if (stripos($customer['email'], $pattern) !== false) {
+                            $isWhitelisted = true;
+                            break;
+                        }
+                    }
+
+                    if (!$isWhitelisted) {
                         if (array_key_exists('tags', $customer) && !empty($customer['tags'])) {
                             $customer['tags'] .= ',review_email';
                         } else {
                             $customer['tags'] = 'review_email';
                         }
                     }
-                }
 
-                if (filter_var($customer['email'], FILTER_VALIDATE_EMAIL) !== false) {
-                    $customer['email'] = mb_strtolower($customer['email']);
-                } else {
-                    unset($customer['email']);
+                    $validatedEmail = filter_var($customer['email'], FILTER_VALIDATE_EMAIL) !== false
+                        ? mb_strtolower($customer['email'])
+                        : $customer['email'];
+                    $customer['email'] = $validatedEmail;
                 }
             }
 


### PR DESCRIPTION
Resuelve la siguiente problematica: Si un cliente contiene en el email: [-noreply@mercadolibre.com](mailto:-noreply@mercadolibre.com) o [mail.mercadolibre.com](http://mail.mercadolibre.com/):
- Si el cliente tiene otros datos además del email, este se reemplaza por `noemail@noemail.com` y el resto de la información se mantiene.
- Si el email es el único dato del cliente, se deshabilita la contactabilidad (`mailing_enabled = 'disabled'`) y se conserva el email original.

Tambien, se implementan y centralizan algunas funcionalidades de manejo de emails.

Antes:
<img width="835" height="674" alt="image" src="https://github.com/user-attachments/assets/882157ad-8aa5-4dd4-b961-6152605bac5c" />

Despues:
<img width="826" height="698" alt="image" src="https://github.com/user-attachments/assets/106bd1e1-69ff-4f19-80ee-bb5eb7ffdef9" />

