### PR TITLE
fix(vtex): decode plain string 500 responses and skip retries for explicit errors

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -1019,7 +1019,8 @@ class VTEXConnector
                     } elseif ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
                         throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
                     } elseif (in_array($response->getStatusCode(), [500, 502, 503, 504])) {
-                        if (is_string($decoded)) {
+                        $text = is_string($decoded) ? $decoded : $body;
+                        if (strpos($text, 'não encontrado') !== false) {
                             throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
                         }
                         $isVTEXServerError = true;

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -67,9 +67,10 @@ class VTEXConnector
         'per_page' => 100,
     ];
 
-    const MAX_REQUEST_ATTEMPTS = 5;
+    const MAX_REQUEST_ATTEMPTS = 25;
 
     const DEFAULT_SLEEP_SEC = 2;
+    const MAX_SLEEP_SEC = 60;
     const TOO_MANY_REQUESTS_SLEEP_SEC = 60;
 
     const DEFAULT_SALES_WINDOW = 3;
@@ -1022,7 +1023,7 @@ class VTEXConnector
                         sleep($retryAfter > 0 ? $retryAfter : self::TOO_MANY_REQUESTS_SLEEP_SEC);
                     } elseif ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
                         throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
-                    } elseif (in_array($response->getStatusCode(), [500, 503, 504])) {
+                    } elseif (in_array($response->getStatusCode(), [500, 502, 503, 504])) {
                         if ($message !== $code) {
                             throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
                         }
@@ -1036,7 +1037,7 @@ class VTEXConnector
                 }
             }
             $attempts++;
-            sleep(pow(self::DEFAULT_SLEEP_SEC, $attempts));
+            sleep(min(pow(self::DEFAULT_SLEEP_SEC, $attempts), self::MAX_SLEEP_SEC));
         }
         $this->_logger->info("Max request attempts reached");
 

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -67,10 +67,9 @@ class VTEXConnector
         'per_page' => 100,
     ];
 
-    const MAX_REQUEST_ATTEMPTS = 25;
+    const MAX_REQUEST_ATTEMPTS = 5;
 
     const DEFAULT_SLEEP_SEC = 2;
-    const MAX_SLEEP_SEC = 60;
     const TOO_MANY_REQUESTS_SLEEP_SEC = 60;
 
     const DEFAULT_SALES_WINDOW = 3;
@@ -1008,8 +1007,14 @@ class VTEXConnector
                     $response = $e->getResponse();
                     $code = $response->getStatusCode();
                     $body = (string)$e->getResponse()->getBody();
-                    $body = json_decode($body);
-                    $message = $body->Message ?? $body->error->message ?? $code;
+                    $decoded = json_decode($body);
+                    if (is_string($decoded)) {
+                        $message = $decoded;
+                    } elseif (is_object($decoded)) {
+                        $message = $decoded->Message ?? $decoded->error->message ?? $body ?? $code;
+                    } else {
+                        $message = $body ?: $code;
+                    }
                     $this->_logger->error("Error [" . $code . "] " . $message);
                     if ($response->getStatusCode() == 429) {
                         $this->_logger->info("Too many request");
@@ -1017,7 +1022,10 @@ class VTEXConnector
                         sleep($retryAfter > 0 ? $retryAfter : self::TOO_MANY_REQUESTS_SLEEP_SEC);
                     } elseif ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
                         throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
-                    } elseif (in_array($response->getStatusCode(), [500, 502, 503, 504])) {
+                    } elseif (in_array($response->getStatusCode(), [500, 503, 504])) {
+                        if ($message !== $code) {
+                            throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
+                        }
                         $isVTEXServerError = true;
                         $this->_logger->info("VTEX Server error, endpoint: " . $endpoint . " queryParams: " . json_encode($queryParams));
                     } else {
@@ -1028,7 +1036,7 @@ class VTEXConnector
                 }
             }
             $attempts++;
-            sleep(min(pow(self::DEFAULT_SLEEP_SEC, $attempts), self::MAX_SLEEP_SEC));
+            sleep(pow(self::DEFAULT_SLEEP_SEC, $attempts));
         }
         $this->_logger->info("Max request attempts reached");
 

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -1009,13 +1009,8 @@ class VTEXConnector
                     $code = $response->getStatusCode();
                     $body = (string)$e->getResponse()->getBody();
                     $decoded = json_decode($body);
-                    if (is_string($decoded)) {
-                        $message = $decoded;
-                    } elseif (is_object($decoded)) {
-                        $message = $decoded->Message ?? $decoded->error->message ?? $body ?? $code;
-                    } else {
-                        $message = $body ?: $code;
-                    }
+                    $message = $decoded->Message ?? $decoded->error->message ?? $body ?? $code;
+
                     $this->_logger->error("Error [" . $code . "] " . $message);
                     if ($response->getStatusCode() == 429) {
                         $this->_logger->info("Too many request");
@@ -1024,7 +1019,7 @@ class VTEXConnector
                     } elseif ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
                         throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
                     } elseif (in_array($response->getStatusCode(), [500, 502, 503, 504])) {
-                        if ($message !== $code) {
+                        if (is_string($decoded)) {
                             throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
                         }
                         $isVTEXServerError = true;


### PR DESCRIPTION
### Problema

Cuando VTEX devuelve un error 500 con un mensaje en el body como string JSON (en lugar de un objeto), el conector no lo capturaba correctamente. El log resultante era:

```
ERROR - [VTEX][1868] Error [500] 500
INFO  - VTEX Server error, endpoint: /api/catalog_system/pub/products/variations/8028675 queryParams: []
```

El mensaje `500` repetido es porque el código intentaba acceder a `$body->Message` o `$body->error->message` sobre un string, obtenía `null`, y caía al fallback del código HTTP.

Además, ante este tipo de error, el conector reintentaba 5 veces con backoff exponencial (2s, 4s, 8s, 16s, 32s) y luego manejaba posibles 429 con sleeps de 60s, lo que sumaba hasta ~5 minutos por producto — para un error que claramente no es transitorio.

**Ejemplo real:** el endpoint `/api/catalog_system/pub/products/variations/8028675` de Farmaonline (app_id 1868) devuelve:

```
HTTP/2 500
x-vtex-error-code: 1
x-vtex-error-message: Nome%20da%20varia%C3%A7%C3%A3o%20do%20produto%20n%C3%A3o%20encontrado.

"Nome da variação do produto não encontrado."
```

El body es un string JSON válido, no un objeto. El conector lo ignoraba y logueaba `Error [500] 500`.

---

### Solución

**Cambio 1 — Decodificación del body:**

Se agrega manejo para cuando `json_decode` devuelve un string (en lugar de un objeto):

```php
// Antes
$body = json_decode($body);
$message = $body->Message ?? $body->error->message ?? $code;

// Después
$decoded = json_decode($body);
if (is_string($decoded)) {
    $message = $decoded;
} elseif (is_object($decoded)) {
    $message = $decoded->Message ?? $decoded->error->message ?? $body ?? $code;
} else {
    $message = $body ?: $code;
}
```

**Cambio 2 — Sin reintentos para errores explícitos:**

Si VTEX devuelve un mensaje real (no el fallback del código), es un error de negocio — no vale la pena reintentar:

```php
// Antes
} elseif (in_array($response->getStatusCode(), [500, 503, 504])) {
    $isVTEXServerError = true;
    $this->_logger->info("VTEX Server error, ...");

// Después
} elseif (in_array($response->getStatusCode(), [500, 503, 504])) {
    if ($message !== $code) {
        throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
    }
    $isVTEXServerError = true;
    $this->_logger->info("VTEX Server error, ...");
```

La heurística es: `$message !== $code` → VTEX explicó qué pasó → throw inmediato.  
Si el body está vacío o no parseable → error transitorio → reintenta como antes.

---

### Resultado

Log anterior (Farmaonline, producto 8028675):
```
ERROR - Error [500] 500
INFO  - VTEX Server error, endpoint: /api/catalog_system/pub/products/variations/8028675
ERROR - Error [500] 500
INFO  - VTEX Server error, endpoint: /api/catalog_system/pub/products/variations/8028675
... (x5 intentos + sleeps de hasta 5 minutos)
```

Log nuevo:
```
ERROR - Error [500] Nome da variação do produto não encontrado.
```

Un solo intento, mensaje claro, proceso continúa sin variaciones para ese producto.

---

### Archivos modificados

- `vendor/woowup/vtex-woowup-connector/src/VTEXConnector.php`