### PR TITLE
fix(historical): filter SKU list by sales channel when products_saleschannel

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -443,6 +443,16 @@ class VTEXConnector
 
     protected function getSkuIdList()
     {
+        $salesChannel = $this->accountConfig['products_sales_channel'] ?? null;
+
+        $endpoint = $salesChannel
+            ? '/api/catalog_system/pvt/sku/stockkeepingunitidsbysaleschannel'
+            : '/api/catalog_system/pvt/sku/stockkeepingunitids';
+
+        if ($salesChannel) {
+            $this->_logger->info("Filtering historical products by sales channel: $salesChannel");
+        }
+
         $skuIdList = [];
 
         $params = [
@@ -450,19 +460,23 @@ class VTEXConnector
             'pagesize' => self::HISTORICAL_PRODUCTS_SEARCH_LIMIT
         ];
 
+        if ($salesChannel) {
+            $params['sc'] = $salesChannel;
+        }
+
         do {
             $params['page']++;
 
-            $response = $this->_get('/api/catalog_system/pvt/sku/stockkeepingunitids', $params);
+            $response = $this->_get($endpoint, $params);
             if ($response->getStatusCode() !== 200) {
                 throw new \Exception($response->getReasonPhrase(), $response->getStatusCode());
             }
 
             $vtexSkuIds = json_decode($response->getBody());
 
-            $skuIdList = array_merge($skuIdList, $vtexSkuIds);
+            $skuIdList = array_merge($skuIdList, $vtexSkuIds ?? []);
 
-        } while (!empty(json_decode($response->getBody())));
+        } while (!empty($vtexSkuIds));
 
         return $skuIdList;
     }


### PR DESCRIPTION
## Problema

Las cuentas VTEX con catálogo multi-marca descargaban **todos** los SKUs del catálogo compartido al correr `vtex:historicalproducts`, sin importar a qué sales channel pertenecía cada producto.

Caso concreto: **ColeHaan (1834)** comparte catálogo con New Balance, Cat, Timberland, Crocs y otras marcas. El historical procesaba **41.252 SKUs** (~5.8 horas) cuando solo **3.924 pertenecen al sales channel Cole-Haan (id: 6)** — el 90% era ruido de otras marcas.

El sync diario (`vtex:products`) ya filtraba correctamente via `sc=` en `/pub/products/search`, pero el historical usaba un endpoint distinto que no filtraba.

## Investigación

Se investigó si VTEX expone un endpoint equivalente a `stockkeepingunitids` con filtro por sales channel. Resultado: **sí existe y está documentado oficialmente**.

### Endpoint verificado contra API real de ColeHaan (1834)

```
GET /api/catalog_system/pvt/sku/stockkeepingunitidsbysaleschannel?sc=6&page=1&pagesize=1000
```

| | Endpoint | SKUs devueltos |
|---|---|---|
| **Sin filtro** (actual) | `/pvt/sku/stockkeepingunitids` | 41.252 |
| **Con filtro sc=6** (nuevo) | `/pvt/sku/stockkeepingunitidsbysaleschannel?sc=6` | 3.924 |

**Reducción: 90.5%**

### Características del endpoint filtrado

- **Autenticación**: misma que el actual (appKey + appToken privado)
- **Paginación**: mismos parámetros (`page`, `pagesize` hasta 1.000 por página)
- **Productos inactivos**: sí los incluye — devuelve todos los SKUs asociados al
  sales channel, activos e inactivos. La validación de actividad queda a cargo del
  conector, igual que con el endpoint actual.
- **Drop-in replacement**: misma firma de respuesta (array de IDs enteros)

## Solución

En `getSkuIdList()`: si `products_sales_channel` está configurado en `accountConfig`, usar `stockkeepingunitidsbysaleschannel?sc={id}` en lugar de `stockkeepingunitids`.

El cambio es **opt-in** — solo afecta cuentas que tengan `products_sales_channel` definido en `config/vtex.php`. El resto usa el endpoint actual sin cambios.

También se corrige un bug menor preexistente: `json_decode($response->getBody())` se llamaba dos veces por iteración (una para el merge, otra en el `while`). Ahora se reutiliza `$vtexSkuIds`.

## Cuentas impactadas

| app_id | Cuenta | SC | Reducción estimada |
|--------|--------|----|--------------------|
| 1834 | ColeHaan (Paraguay) | 6 | 41.252 → 3.924 SKUs (~90%) |
| 1856 | Sportotal (Grupo Vallejo) | 1 | por confirmar |
| 1857 | Freekick (Grupo Vallejo) | 4 | por confirmar |

## Cambios

- `src/VTEXConnector.php` — `getSkuIdList()`