### PR TITLE
feat(orders): add onOrdersFound callback hook to importOrders

### DIFF
--- a/src/VTEXWoowUp.php
+++ b/src/VTEXWoowUp.php
@@ -40,6 +40,14 @@ class VTEXWoowUp
 
     protected $ignoreOptIn;
 
+    /** @var callable|null */
+    private $onOrdersFound = null;
+
+    public function setOnOrdersFound(callable $callback): void
+    {
+        $this->onOrdersFound = $callback;
+    }
+
     public function __construct($vtexConfig, $httpClient, $logger, $woowupClient, $errorHandler, $features = null, $notifier = null, $ignoreOptIn = false, $accountConfig = [])
     {
         $this->vtexConnector = new VTEXConnector($vtexConfig, $httpClient, $logger, $features, $accountConfig);
@@ -147,6 +155,10 @@ class VTEXWoowUp
 
         $countOrders = $this->vtexConnector->countOrders($fromDate, $toDate, $daysFrom);
         $this->logger->info("Found " . $countOrders . " orders to import");
+
+        if ($this->onOrdersFound !== null) {
+            ($this->onOrdersFound)($countOrders);
+        }
 
         // Pipeline = Download(VTEX) + ... + Map (VTEX->WoowUp) + ... + Upload(WoowUp)
         if (!$this->downloadStage) {


### PR DESCRIPTION
 Agrega un callback setOnOrdersFound en VTEXWoowUp que se ejecuta luego de contar las órdenes en importOrders(), permitiendo que quien instancie la clase reaccione al conteo sin necesidad de modificarla. 
<img width="1230" height="170" alt="image" src="https://github.com/user-attachments/assets/1d3eb4cc-48e2-4f64-bd11-09a9f930383b" />
