### PR TITLE
feat(customers): add historical flag to filter by createdIn date field

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -543,13 +543,15 @@ class VTEXConnector
         } while (((100 * $page) < $totalCustomers) && !empty(json_decode($response->getBody())));
     }
 
-    public function getCustomers($fromDate = null, $toDate = null, $dataEntity = "CL", $dateField = 'updatedIn')
+    public function getCustomers($fromDate = null, $toDate = null, $dataEntity = "CL", $dateField = 'updatedIn', $startPage = 1)
     {
         if($toDate === null){
             $toDate = date('Y-m-d', strtotime('+1 days'));
         }
 
-        $this->_logger->info("Getting updated and created customers from date " . $fromDate. " to " . $toDate . " and dataEntity $dataEntity");
+        $startPage = max(1, (int) $startPage);
+
+        $this->_logger->info("Getting customers by $dateField from $fromDate to $toDate and dataEntity $dataEntity" . ($startPage > 1 ? " (starting from page $startPage)" : ""));
 
         if ($dateField === 'createdIn') {
             $where = "(createdIn<$toDate) AND (createdIn>$fromDate)";
@@ -561,9 +563,9 @@ class VTEXConnector
             '_fields' => 'id',
             '_where' => $where,
         ];
-        $offset = 0;
         $limit  = 100;
-        $page   = 0;
+        $offset = ($startPage - 1) * $limit;
+        $page   = $startPage - 1;
         do {
             $page++;
             $this->_logger->info("Offset: " . $offset . ", Limit: " . $limit . ", Page: " . $page);
@@ -584,6 +586,9 @@ class VTEXConnector
                 $totalCustomers = 0;
             } else {
                 $totalCustomers = (int) $totalHeader[0];
+            }
+            if ($page === $startPage) {
+                $this->_logger->info("Total customers: $totalCustomers — Total pages: " . ceil($totalCustomers / $limit));
             }
             $tokenHeader = $response->getHeader('X-VTEX-MD-TOKEN');
             if (!empty($tokenHeader)) {

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -543,16 +543,23 @@ class VTEXConnector
         } while (((100 * $page) < $totalCustomers) && !empty(json_decode($response->getBody())));
     }
 
-    public function getCustomers($fromDate = null, $toDate = null, $dataEntity = "CL")
+    public function getCustomers($fromDate = null, $toDate = null, $dataEntity = "CL", $dateField = 'updatedIn')
     {
         if($toDate === null){
             $toDate = date('Y-m-d', strtotime('+1 days'));
         }
 
         $this->_logger->info("Getting updated and created customers from date " . $fromDate. " to " . $toDate . " and dataEntity $dataEntity");
+
+        if ($dateField === 'createdIn') {
+            $where = "(createdIn<$toDate) AND (createdIn>$fromDate)";
+        } else {
+            $where = "((updatedIn<$toDate) AND (updatedIn>$fromDate)) OR ((updatedIn is null) AND (createdIn<$toDate) AND (createdIn>$fromDate))";
+        }
+
         $params = [
             '_fields' => 'id',
-            '_where' => "((updatedIn<$toDate) AND (updatedIn>$fromDate)) OR ((updatedIn is null) AND (createdIn<$toDate) AND (createdIn>$fromDate))",
+            '_where' => $where,
         ];
         $offset = 0;
         $limit  = 100;

--- a/src/VTEXWoowUp.php
+++ b/src/VTEXWoowUp.php
@@ -222,7 +222,7 @@ class VTEXWoowUp
         return true;
     }
 
-    public function importCustomers($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL")
+    public function importCustomers($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $historical = false)
     {
         if (!$fromDate) {
             $fromDate = ($days) ? date('Y-m-d', strtotime("-$days days")) : date('Y-m-d', strtotime("-3 days"));
@@ -247,8 +247,9 @@ class VTEXWoowUp
             );
         }
 
+        $dateField = $historical ? 'createdIn' : 'updatedIn';
         $this->preparePipeline();
-        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity) as $vtexCustomers) {
+        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity, $dateField) as $vtexCustomers) {
             foreach ($vtexCustomers as $vtexCustomer) {
                 $vtexCustomerId = $vtexCustomer->id;
                 if (!$vtexCustomerId) {
@@ -272,7 +273,7 @@ class VTEXWoowUp
         return ['customers' => $woowupStats];
     }
 
-    public function importCustomersWithYield($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $toFile = false)
+    public function importCustomersWithYield($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $toFile = false, $historical = false)
     {
         if (!$fromDate) {
             $fromDate = ($days) ? date('Y-m-d', strtotime("-$days days")) : date('Y-m-d', strtotime("-3 days"));
@@ -280,7 +281,8 @@ class VTEXWoowUp
 
         $this->logger->info("Importing customers from $fromDate and entity $dataEntity");
         $this->initProcessCustomers($dataEntity,$debug);
-        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity) as $vtexCustomers) {
+        $dateField = $historical ? 'createdIn' : 'updatedIn';
+        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity, $dateField) as $vtexCustomers) {
             yield $vtexCustomers;
         }
     }

--- a/src/VTEXWoowUp.php
+++ b/src/VTEXWoowUp.php
@@ -222,7 +222,7 @@ class VTEXWoowUp
         return true;
     }
 
-    public function importCustomers($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $historical = false)
+    public function importCustomers($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $historical = false, $startPage = 1)
     {
         if (!$fromDate) {
             $fromDate = ($days) ? date('Y-m-d', strtotime("-$days days")) : date('Y-m-d', strtotime("-3 days"));
@@ -249,7 +249,7 @@ class VTEXWoowUp
 
         $dateField = $historical ? 'createdIn' : 'updatedIn';
         $this->preparePipeline();
-        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity, $dateField) as $vtexCustomers) {
+        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity, $dateField, $startPage) as $vtexCustomers) {
             foreach ($vtexCustomers as $vtexCustomer) {
                 $vtexCustomerId = $vtexCustomer->id;
                 if (!$vtexCustomerId) {
@@ -273,7 +273,7 @@ class VTEXWoowUp
         return ['customers' => $woowupStats];
     }
 
-    public function importCustomersWithYield($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $toFile = false, $historical = false)
+    public function importCustomersWithYield($fromDate = null, $toDate = null, $days= null, $debug = false, $dataEntity = "CL", $toFile = false, $historical = false, $startPage = 1)
     {
         if (!$fromDate) {
             $fromDate = ($days) ? date('Y-m-d', strtotime("-$days days")) : date('Y-m-d', strtotime("-3 days"));
@@ -282,7 +282,7 @@ class VTEXWoowUp
         $this->logger->info("Importing customers from $fromDate and entity $dataEntity");
         $this->initProcessCustomers($dataEntity,$debug);
         $dateField = $historical ? 'createdIn' : 'updatedIn';
-        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity, $dateField) as $vtexCustomers) {
+        foreach ($this->vtexConnector->getCustomers($fromDate, $toDate, $dataEntity, $dateField, $startPage) as $vtexCustomers) {
             yield $vtexCustomers;
         }
     }


### PR DESCRIPTION
Adds $dateField param to getCustomers() and $historical param to importCustomers() and importCustomersWithYield(), allowing historical imports to filter by createdIn instead of updatedIn.