### PR TITLE
fix(vtex): recover from scroll token expiry by fast-forwarding cursor to failed page

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -72,6 +72,7 @@ class VTEXConnector
     const DEFAULT_SLEEP_SEC = 2;
     const MAX_SLEEP_SEC = 60;
     const TOO_MANY_REQUESTS_SLEEP_SEC = 60;
+    const SCROLL_TOKEN_RESTART_LIMIT = 3;
 
     const DEFAULT_SALES_WINDOW = 3;
     const VTEX_PAGE_LIMIT = 30;
@@ -598,11 +599,42 @@ class VTEXConnector
             $this->_logger->info("Cursor ready at page $startPage. Total customers: $totalCustomers — Total pages: " . ceil($totalCustomers / $limit));
         }
 
+        $tokenRestarts = 0;
+
         do {
             $page++;
             $this->_logger->info("Offset: " . (($page - 1) * $limit) . ", Limit: " . $limit . ", Page: " . $page);
 
-            $response = $this->_getCustomersWithRetry('/api/dataentities/' . $dataEntity . '/scroll', $params, $requestHeaders, $page);
+            $fetched = false;
+            while (!$fetched) {
+                try {
+                    $response = $this->_getCustomersWithRetry('/api/dataentities/' . $dataEntity . '/scroll', $params, $requestHeaders, $page);
+                    $fetched = true;
+                } catch (Exceptions\VTEXRequestException $e) {
+                    if ($e->getCode() === 400
+                        && strpos($e->getMessage(), 'Operation not found for this token') !== false
+                        && $tokenRestarts < self::SCROLL_TOKEN_RESTART_LIMIT
+                    ) {
+                        $tokenRestarts++;
+                        $this->_logger->warning("VTEX scroll token expired on page $page (restart $tokenRestarts/" . self::SCROLL_TOKEN_RESTART_LIMIT . "), fast-forwarding to refresh cursor...");
+                        unset($params['_token']);
+                        for ($warmup = 1; $warmup < $page; $warmup++) {
+                            $warmupResponse = $this->_getCustomersWithRetry('/api/dataentities/' . $dataEntity . '/scroll', $params, $requestHeaders, $warmup);
+                            $warmupToken = $warmupResponse->getHeader('X-VTEX-MD-TOKEN');
+                            if (!empty($warmupToken)) {
+                                $params['_token'] = $warmupToken[0];
+                            } else {
+                                unset($params['_token']);
+                            }
+                            $this->_logger->info("Token refresh fast-forward: page $warmup / " . ($page - 1));
+                        }
+                        $this->_logger->info("Token refreshed, retrying page $page");
+                    } else {
+                        throw $e;
+                    }
+                }
+            }
+
             if ($response->getStatusCode() !== 200) {
                 throw new \Exception($response->getReasonPhrase(), $response->getStatusCode());
             }

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -599,6 +599,10 @@ class VTEXConnector
             $this->_logger->info("Cursor ready at page $startPage. Total customers: $totalCustomers — Total pages: " . ceil($totalCustomers / $limit));
         }
 
+        // Global counter across all pages — does NOT reset after a successful recovery.
+        // In long scrolls (thousands of pages) where token expiry is sporadic, this means
+        // SCROLL_TOKEN_RESTART_LIMIT failures total (not per page) will abort the run.
+        // Raise SCROLL_TOKEN_RESTART_LIMIT if recurring expiries are observed in practice.
         $tokenRestarts = 0;
 
         do {
@@ -610,7 +614,7 @@ class VTEXConnector
                 try {
                     $response = $this->_getCustomersWithRetry('/api/dataentities/' . $dataEntity . '/scroll', $params, $requestHeaders, $page);
                     $fetched = true;
-                } catch (Exceptions\VTEXRequestException $e) {
+                } catch (VTEXRequestException $e) {
                     if ($e->getCode() === 400
                         && strpos($e->getMessage(), 'Operation not found for this token') !== false
                         && $tokenRestarts < self::SCROLL_TOKEN_RESTART_LIMIT


### PR DESCRIPTION
### Problema

Los conectores VTEX que descargan clientes via `/api/dataentities/CL/scroll` fallaban con HTTP 400 cuando el cursor del scroll expiraba en el servidor de VTEX:

```
Codigo de Error: 400 Mensaje: Operation not found for this token: 'FGluY2x1ZGVfY29udGV4dF91...' Endpoint /api/dataentities/CL/scroll
```

El endpoint `/scroll` es cursor-based: cada respuesta devuelve un token (`X-VTEX-MD-TOKEN`) que identifica la posición del cursor server-side. Ese cursor tiene un TTL corto en VTEX (no documentado con precisión, se reportan valores entre 15 y 30 minutos según el cluster). Si entre dos requests consecutivas pasa demasiado tiempo —por throttling, lentitud de red o volumen elevado de datos— VTEX descarta el cursor.

Antes del fix, `_request()` capturaba el 400 de Guzzle y lanzaba `VTEXRequestException`. Esta excepción propagaba sin catch hasta matar el proceso, requiriendo reinicio manual desde página 1.

### Solución

Cuando `getCustomers()` recibe una `VTEXRequestException` con código 400 y mensaje `"Operation not found for this token"`, en lugar de dejar caer el proceso:

1. **Descarta el token expirado** de los params.
2. **Hace fast-forward silencioso** desde la página 1 hasta la página anterior a la que falló, consumiendo las respuestas solo para avanzar el cursor y obtener un token fresco. Es la misma mecánica que ya existía para el parámetro `startPage`.
3. **Reintenta la página fallida** con el token renovado y continúa el scroll normalmente.

El manejo está dentro de un `while (!$fetched)` por página, lo que permite recuperarse de múltiples expiraciones consecutivas en la misma página. Hay un límite de `SCROLL_TOKEN_RESTART_LIMIT = 3` reinicios por ejecución para evitar loops infinitos ante una degradación severa.

### Archivos modificados

- `vendor/woowup/vtex-woowup-connector/src/VTEXConnector.php`

### Ejemplos probados

**Token expira en página 2 de 3:**
```
[info]    Offset: 0,   Page: 1 → Success (token: tok-1)
[info]    Offset: 100, Page: 2
[error]   Error [400] Operation not found for this token: 'FAKE_TOKEN'
[warning] VTEX scroll token expired on page 2 (restart 1/3), fast-forwarding to refresh cursor...
[info]    Token refresh fast-forward: page 1 / 1
[info]    Token refreshed, retrying page 2 → Success
[info]    Offset: 200, Page: 3 → Success
→ 250 clientes entregados sin duplicados
```

**Token expira dos veces en la misma página:**
```
[warning] VTEX scroll token expired on page 3 (restart 1/3), fast-forwarding...
[warning] VTEX scroll token expired on page 3 (restart 2/3), fast-forwarding...
[info]    Token refreshed, retrying page 3 → Success
→ Se recupera en ambas ocasiones
```

**Token expira 4 veces (límite superado):**
```
[warning] VTEX scroll token expired on page 1 (restart 1/3) → retry
[warning] VTEX scroll token expired on page 1 (restart 2/3) → retry
[warning] VTEX scroll token expired on page 1 (restart 3/3) → retry
[error]   Error [400] Operation not found for this token: '...'
→ Lanza excepción en el 4to fallo (comportamiento anterior)
```