### PR TITLE
feat(carts): add abandoned cart import pipeline

### DIFF
--- a/src/Stages/Carts/VTEXWoowUpCartMapper.php
+++ b/src/Stages/Carts/VTEXWoowUpCartMapper.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace WoowUpConnectors\Stages\Carts;
+
+use League\Pipeline\StageInterface;
+use WoowUpConnectors\Stages\VTEXConfig;
+use WoowUpV2\Models\AbandonedCartModel;
+
+class VTEXWoowUpCartMapper implements StageInterface
+{
+    private $vtexConnector;
+    private $logger;
+
+    public function __construct($vtexConnector, $logger)
+    {
+        $this->vtexConnector = $vtexConnector;
+        $this->logger        = $logger;
+    }
+
+    public function __invoke($cartdata)
+    {
+        if (empty($cartdata)) {
+            return null;
+        }
+
+        $quantities = $this->parseQuantities($cartdata['rclastcart'] ?? '');
+        if (empty($quantities)) {
+            $this->logger->info('No parseable SKU quantities in rclastcart.');
+            return null;
+        }
+
+        $appId = $this->vtexConnector->getAppId();
+        $cart  = new AbandonedCartModel();
+        $cart->setSource('vtex');
+        $cart->setEmail($cartdata['email']);
+        $cart->setExternalId(substr(md5($cartdata['email'] . ($cartdata['rclastcart'] ?? '')), 0, 20));
+        $cart->setTotalPrice((float) ($cartdata['rclastcartvalue'] ?? 0));
+        $cart->setCreatetime(date('c'));
+        $recoverUrl = $this->buildRecoverUrl($cartdata);
+        if ($recoverUrl) {
+            $cart->setRecoverUrl($recoverUrl);
+        }
+
+        if (!empty($cartdata['document'])) {
+            $cart->setDocument($cartdata['document']);
+        }
+
+        $productsAdded = 0;
+        foreach ($cartdata['carttag']['Scores'] as $numericSkuId => $scores) {
+            $price = $scores[0]['Point'] ?? null;
+            if ($price === null || !isset($quantities[$numericSkuId])) {
+                $this->logger->info("Missing price or quantity for SKU $numericSkuId. Skipping.");
+                continue;
+            }
+
+            $refId = $this->resolveSkuRefId($numericSkuId, $appId);
+            if (!$refId) {
+                $this->logger->info("Could not resolve RefId for SKU $numericSkuId. Skipping.");
+                continue;
+            }
+
+            $cart->addProduct([
+                'sku'        => $refId,
+                'quantity'   => (int) $quantities[$numericSkuId],
+                'unit_price' => (float) $price,
+            ]);
+            $productsAdded++;
+        }
+
+        if ($productsAdded === 0) {
+            $this->logger->info('Cart has no valid products after SKU mapping.');
+            return null;
+        }
+
+        return [
+            'cart'     => $cart,
+            'customer' => $this->buildCustomer($cartdata),
+        ];
+    }
+
+    private function resolveSkuRefId($numericSkuId, int $appId): ?string
+    {
+        try {
+            $skuData = $this->vtexConnector->getHistoricalSingleProduct($numericSkuId);
+            if (!$skuData) {
+                return null;
+            }
+            return VTEXConfig::mapsChildProducts($appId)
+                ? ($skuData->AlternateIds->RefId ?? null)
+                : ($skuData->ProductRefId ?? null);
+        } catch (\Exception $e) {
+            $this->logger->info("Error resolving RefId for SKU $numericSkuId: " . $e->getMessage());
+            return null;
+        }
+    }
+
+    private function buildCustomer(array $cartdata): ?array
+    {
+        if (empty($cartdata['email'])) {
+            return null;
+        }
+
+        $customer = ['email' => $cartdata['email']];
+        if (!empty($cartdata['firstName'])) {
+            $customer['first_name'] = $cartdata['firstName'];
+        }
+        if (!empty($cartdata['lastName'])) {
+            $customer['last_name'] = $cartdata['lastName'];
+        }
+        if (!empty($cartdata['document'])) {
+            $customer['document'] = $cartdata['document'];
+        }
+
+        return $customer;
+    }
+
+    private function buildRecoverUrl(array $cartdata): ?string
+    {
+        $url = $cartdata['rclastcart'] ?? null;
+        if (!$url) {
+            return null;
+        }
+        if (strpos($url, 'http') === 0) {
+            return $url;
+        }
+        $accountName = $cartdata['accountName'] ?? null;
+        if (!$accountName) {
+            return $url;
+        }
+        return "https://{$accountName}.vtexcommercestable.com.br/checkout/cart/" . $url;
+    }
+
+    private function parseQuantities(string $url): array
+    {
+        $quantities = [];
+        preg_match_all('/sku=(\w+)&qty=(\d+)/', $url, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $quantities[$match[1]] = (int) $match[2];
+        }
+        return $quantities;
+    }
+}

--- a/src/Stages/Carts/WoowUpCartUploader.php
+++ b/src/Stages/Carts/WoowUpCartUploader.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace WoowUpConnectors\Stages\Carts;
+
+use GuzzleHttp\Exception\RequestException;
+use League\Pipeline\StageInterface;
+use WoowUpV2\Models\AbandonedCartModel;
+use WoowUpV2\Models\UserModel;
+
+class WoowUpCartUploader implements StageInterface
+{
+    private $woowupV2Client;
+    private $logger;
+    private $woowupStats;
+
+    public function __construct($woowupV2Client, $logger)
+    {
+        $this->woowupV2Client = $woowupV2Client;
+        $this->logger         = $logger;
+        $this->resetWoowupStats();
+    }
+
+    public function __invoke($payload)
+    {
+        if (!$payload || !isset($payload['cart'])) {
+            return null;
+        }
+
+        /** @var AbandonedCartModel $cart */
+        $cart         = $payload['cart'];
+        $customerData = $payload['customer'] ?? null;
+
+        if ($customerData) {
+            $this->createOrCheckCustomer($customerData);
+        }
+
+        try {
+            $this->woowupV2Client->abandonedCarts->create($cart);
+            $this->logger->info("Cart {$cart->getExternalId()} created successfully.");
+            $this->woowupStats['created']++;
+            return true;
+        } catch (RequestException $e) {
+            $body = $e->hasResponse() ? json_decode((string) $e->getResponse()->getBody(), true) : [];
+            $code = $body['code'] ?? (string) $e->getCode();
+            $msg  = $body['payload']['errors'][0] ?? $body['message'] ?? $e->getMessage();
+            $this->logger->info("Error uploading cart: [$code] $msg");
+            $this->woowupStats['failed'][] = $cart;
+            return false;
+        }
+    }
+
+    private function createOrCheckCustomer(array $customerData): void
+    {
+        $identity = array_filter([
+            'email'    => $customerData['email'] ?? '',
+            'document' => $customerData['document'] ?? '',
+        ]);
+
+        if (empty($identity)) {
+            return;
+        }
+
+        try {
+            if (!$this->woowupV2Client->users->exist($identity)) {
+                $customer = new UserModel();
+                $customer->setEmail($customerData['email']);
+                if (!empty($customerData['first_name'])) {
+                    $customer->setFirstName($customerData['first_name']);
+                }
+                if (!empty($customerData['last_name'])) {
+                    $customer->setLastName($customerData['last_name']);
+                }
+                if (!empty($customerData['document'])) {
+                    $customer->setDocument($customerData['document']);
+                }
+                $this->woowupV2Client->users->create($customer);
+                $this->logger->info("Customer {$customerData['email']} created.");
+            } else {
+                $this->logger->info("Customer {$customerData['email']} already exists.");
+            }
+        } catch (RequestException $e) {
+            $body = $e->hasResponse() ? json_decode((string) $e->getResponse()->getBody(), true) : [];
+            $code = $body['code'] ?? (string) $e->getCode();
+            $msg  = $body['payload']['errors'][0] ?? $body['message'] ?? $e->getMessage();
+            if ($code === 'internal_error' && strpos($msg, 'existente') !== false) {
+                return;
+            }
+            $this->logger->info("Error creating/checking customer: [$code] $msg");
+        }
+    }
+
+    public function getWoowupStats(): array
+    {
+        return $this->woowupStats;
+    }
+
+    public function resetWoowupStats(): void
+    {
+        $this->woowupStats = [
+            'created' => 0,
+            'failed'  => [],
+        ];
+    }
+}

--- a/src/VTEXWoowUp.php
+++ b/src/VTEXWoowUp.php
@@ -20,6 +20,8 @@ use WoowUpConnectors\Stages\Products\WoowUpProductDebugger;
 use WoowUpConnectors\Stages\Products\WoowUpProductUploader;
 use WoowUpConnectors\Stages\HistoricalProducts\VTEXWoowUpHistoricalProductMapper;
 use WoowUpConnectors\Stages\HistoricalProducts\WoowUpHistoricalProductUploader;
+use WoowUpConnectors\Stages\Carts\VTEXWoowUpCartMapper;
+use WoowUpConnectors\Stages\Carts\WoowUpCartUploader;
 use League\Pipeline\Pipeline;
 
 class VTEXWoowUp
@@ -462,6 +464,26 @@ class VTEXWoowUp
         $this->resetStages();
 
         return ['products' => $woowupStats];
+    }
+
+    public function importAbandonedCart(array $cartdata, $woowupV2Client, bool $debug = false): bool
+    {
+        if (!$this->mapStage) {
+            $this->setMapStage(new VTEXWoowUpCartMapper($this->vtexConnector, $this->logger));
+        }
+
+        if (!$this->uploadStage) {
+            $this->setUploadStage(
+                $debug
+                    ? new DebugUploadStage()
+                    : new WoowUpCartUploader($woowupV2Client, $this->logger)
+            );
+        }
+
+        $this->preparePipeline();
+        $this->run($cartdata);
+
+        return true;
     }
 
     public function getConnector()


### PR DESCRIPTION
  Pipeline (vtex-woowup-connector)

  VTEXWoowUp::importAbandonedCart()
  - Nuevo método que orquesta el pipeline. No llama resetStages() al final (igual que importSingleProduct()), para que los stages custom configurados por addStages() persistan entre mensajes del
  mismo conector cacheado.
  
  Stages/Carts/VTEXWoowUpCartMapper
  - Parsea las cantidades desde la URL rclastcart (add?sku=X&qty=N&...).
  - Resuelve cada SKU numérico de VTEX a su RefId via getHistoricalSingleProduct(), usando AlternateIds.RefId (modo child) o ProductRefId (modo parent) según VTEXConfig::mapsChildProducts().
  - Construye la URL de recuperación completa (https://{accountName}.vtexcommercestable.com.br/checkout/cart/...) cuando rclastcart es una URL relativa.
  - Retorna ['cart' => AbandonedCartModel, 'customer' => array] o null si el carrito no tiene productos válidos.

  Stages/Carts/WoowUpCartUploader
  - Crea o verifica el cliente en WoowUp antes de subir el carrito.
  - Sube via abandonedCarts->create() del cliente v2.