### PR TITLE
fix(products): retry upsert stripping bloating custom attributes 

### DIFF
--- a/src/Stages/HistoricalProducts/WoowUpHistoricalProductUploader.php
+++ b/src/Stages/HistoricalProducts/WoowUpHistoricalProductUploader.php
@@ -7,6 +7,8 @@ use League\Pipeline\StageInterface;
 
 class WoowUpHistoricalProductUploader implements StageInterface
 {
+    private const MAX_ATTR_STRIP_RETRIES = 5;
+
     protected $woowupClient;
     protected $logger;
     protected $woowupStats;
@@ -43,56 +45,81 @@ class WoowUpHistoricalProductUploader implements StageInterface
         $this->logger->info("[Product] LastCategoryId: {$lastCategoryId}");
         $this->logger->info("---------");
 
-        try {
-            $this->woowupClient->products->update($product['sku'], $product);
-            $this->logger->info("[Product] {$product['sku']} Updated Successfully");
-            $this->woowupStats['updated']++;
-            return true;
-        } catch (RequestException $e) {
-            $errorCode    = $e->getCode();
-            $errorMessage = $e->getMessage();
-            $sku = $product['sku'] ?? 'Product without sku';
-            if ($e->hasResponse()) {
-                $response = $e->getResponse();
-                $responseStatusCode = $response->getStatusCode();
-                if ($responseStatusCode == 404) {
-                    try {
-                        $this->woowupClient->products->create($product);
-                        $this->logger->info("[Product] $sku Created Successfully");
-                        $this->woowupStats['created']++;
-                        return true;
-                    } catch (\Exception $e) {
-                        $this->logger->info("[Product] $sku Failed Creation");
-                        return false;
+        $sku = $product['sku'] ?? 'Product without sku';
+        $errorCode = $errorMessage = null;
+
+        for ($attempt = 0; $attempt <= self::MAX_ATTR_STRIP_RETRIES; $attempt++) {
+            try {
+                $this->woowupClient->products->update($product['sku'], $product);
+                $this->logger->info("[Product] {$product['sku']} Updated Successfully");
+                $this->woowupStats['updated']++;
+                return true;
+            } catch (RequestException $e) {
+                $errorCode    = $e->getCode();
+                $errorMessage = $e->getMessage();
+                if ($e->hasResponse()) {
+                    $response = $e->getResponse();
+                    if ($response->getStatusCode() == 404) {
+                        try {
+                            $this->woowupClient->products->create($product);
+                            $this->logger->info("[Product] $sku Created Successfully");
+                            $this->woowupStats['created']++;
+                            return true;
+                        } catch (\Exception $createEx) {
+                            $this->logger->info("[Product] $sku Failed Creation");
+                            return false;
+                        }
                     }
-                }
-                $body = json_decode((string) $response->getBody(),true);
-                if ($body) {
-                    if (isset($body['code']) && !empty($body['code'])) {
+                    $body = json_decode((string) $response->getBody(), true);
+                    if ($body && isset($body['code']) && !empty($body['code'])) {
                         $errorCode = $body['code'];
-                        switch ($errorCode) {
-                            case 'internal_error':
-                                $errorMessage = $body['message'] ?? '';
-                                break;
-                            default:
-                                $errors = $body['payload']['errors'] ?? [];
-                                $errorMessage = is_array($errors) ? implode(';',$errors) : $errors;
-                                break;
+                        if ($errorCode === 'internal_error') {
+                            $errorMessage = $body['message'] ?? '';
+                        } else {
+                            $errors = $body['payload']['errors'] ?? [];
+                            $errorMessage = is_array($errors) ? implode(';', $errors) : $errors;
                         }
                     }
                 }
+            } catch (\Exception $e) {
+                $errorCode    = $e->getCode();
+                $errorMessage = $e->getMessage();
+                break;
             }
-            $this->logger->info("[Product] $sku Error: Code '" . $errorCode . "', Message '" . $errorMessage . "'");
-            $this->woowupStats['failed'][] = $product;
-            return false;
-        } catch (\Exception $e) {
-            $errorCode    = $e->getCode();
-            $errorMessage = $e->getMessage();
-            $sku = $product['sku'] ?? 'Product without sku';
-            $this->logger->info("[Product] $sku Error: Code '" . $errorCode . "', Message '" . $errorMessage . "'");
-            $this->woowupStats['failed'][] = $product;
-            return false;
+
+            $bloatingAttr = $this->extractBloatingAttribute((string) $errorMessage, array_keys($product['custom_attributes'] ?? []));
+            if ($bloatingAttr === null) {
+                break;
+            }
+            $this->logger->info("[Product] {$sku} Schema limit — retrying without '{$bloatingAttr}'");
+            unset($product['custom_attributes'][$bloatingAttr]);
         }
+
+        $this->logger->info("[Product] $sku Error: Code '" . $errorCode . "', Message '" . $errorMessage . "'");
+        $this->woowupStats['failed'][] = $product;
+        return false;
+    }
+
+    private function extractBloatingAttribute(string $errorMessage, array $existingAttrNames = []): ?string
+    {
+        if (strpos($errorMessage, 'extended attribute definition very long') === false) {
+            return null;
+        }
+        $separatorPos = strpos($errorMessage, ' :: ');
+        if ($separatorPos === false) {
+            return null;
+        }
+        $data = json_decode(substr($errorMessage, $separatorPos + 4), true);
+        foreach ($data['checkbox_breakdown'] ?? [] as $entry) {
+            $name = $entry['name'] ?? null;
+            if ($name === null) {
+                continue;
+            }
+            if (empty($existingAttrNames) || in_array($name, $existingAttrNames, true)) {
+                return $name;
+            }
+        }
+        return null;
     }
 
     public function getWoowupStats()

--- a/src/Stages/Products/WoowUpProductUploader.php
+++ b/src/Stages/Products/WoowUpProductUploader.php
@@ -7,74 +7,84 @@ use League\Pipeline\StageInterface;
 
 class WoowUpProductUploader implements StageInterface
 {
-	protected $woowupClient;
-	protected $logger;
-	protected $woowupStats;
+    private const MAX_ATTR_STRIP_RETRIES = 5;
+
+    protected $woowupClient;
+    protected $logger;
+    protected $woowupStats;
     protected $cleanser;
 
-	public function __construct($woowupClient, $logger, $cleanser)
-	{
-		$this->woowupClient = $woowupClient;
-		$this->logger       = $logger;
+    public function __construct($woowupClient, $logger, $cleanser)
+    {
+        $this->woowupClient = $woowupClient;
+        $this->logger       = $logger;
         $this->cleanser     = $cleanser;
 
-		$this->resetWoowupStats();
+        $this->resetWoowupStats();
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function __invoke($payload)
-	{
+    public function __invoke($payload)
+    {
         $begin = microtime(true);
         $processedProducts = [];
         foreach ($payload as $product) {
             $processedProducts[] = $product;
-    		try {
-                $this->woowupClient->products->update($product['sku'], $product);
-                $this->logger->info("[Product] {$product['sku']} Updated Successfully");
-                $this->logProductData($product);
-                $this->woowupStats['updated']++;
-            } catch (RequestException $e) {
-                $errorCode    = $e->getCode();
-                $errorMessage = $e->getMessage();
-                $sku = $product['sku'] ?? 'Product without sku';
-                if ($e->hasResponse()) {
-                    $response = $e->getResponse();
-                    $responseStatusCode = $response->getStatusCode();
-                    if ($responseStatusCode == 404) {
-                        try {
-                            $this->woowupClient->products->create($product);
-                            $this->logger->info("[Product] $sku Created Successfully");
-                            $this->logProductData($product);
-                            $this->woowupStats['created']++;
-                            continue;
-                        } catch (\Exception $e) {
-                            $this->logger->info("[Product] $sku Failed Creation");
+            $sku = $product['sku'] ?? 'Product without sku';
+            $errorCode = $errorMessage = null;
+
+            for ($attempt = 0; $attempt <= self::MAX_ATTR_STRIP_RETRIES; $attempt++) {
+                try {
+                    $this->woowupClient->products->update($product['sku'], $product);
+                    $this->logger->info("[Product] {$product['sku']} Updated Successfully");
+                    $this->logProductData($product);
+                    $this->woowupStats['updated']++;
+                    $errorCode = null;
+                    break;
+                } catch (RequestException $e) {
+                    $errorCode    = $e->getCode();
+                    $errorMessage = $e->getMessage();
+                    if ($e->hasResponse()) {
+                        $response = $e->getResponse();
+                        if ($response->getStatusCode() == 404) {
+                            try {
+                                $this->woowupClient->products->create($product);
+                                $this->logger->info("[Product] $sku Created Successfully");
+                                $this->logProductData($product);
+                                $this->woowupStats['created']++;
+                                continue 2;
+                            } catch (\Exception $createEx) {
+                                $this->logger->info("[Product] $sku Failed Creation");
+                            }
+                            break;
                         }
-                    }
-                    $body = json_decode((string) $response->getBody(),true);
-                    if ($body) {
-                        if (isset($body['code']) && !empty($body['code'])) {
+                        $body = json_decode((string) $response->getBody(), true);
+                        if ($body && isset($body['code']) && !empty($body['code'])) {
                             $errorCode = $body['code'];
-                            switch ($errorCode) {
-                                case 'internal_error':
-                                    $errorMessage = $body['message'] ?? '';
-                                    break;
-                                default:
-                                    $errors = $body['payload']['errors'] ?? [];
-                                    $errorMessage = is_array($errors) ? implode(';',$errors) : $errors;
-                                    break;
+                            if ($errorCode === 'internal_error') {
+                                $errorMessage = $body['message'] ?? '';
+                            } else {
+                                $errors = $body['payload']['errors'] ?? [];
+                                $errorMessage = is_array($errors) ? implode(';', $errors) : $errors;
                             }
                         }
                     }
+                } catch (\Exception $e) {
+                    $errorCode    = $e->getCode();
+                    $errorMessage = $e->getMessage();
+                    break;
                 }
-                $this->logger->info("[Product] $sku Error: Code '" . $errorCode . "', Message '" . $errorMessage . "'");
-                $this->woowupStats['failed'][] = $product;
 
-            } catch (\Exception $e) {
-                $errorCode    = $e->getCode();
-                $errorMessage = $e->getMessage();
-                $sku = $product['sku'] ?? 'Product without sku';
+                $bloatingAttr = $this->extractBloatingAttribute((string) $errorMessage, array_keys($product['custom_attributes'] ?? []));
+                if ($bloatingAttr === null) {
+                    break;
+                }
+                $this->logger->info("[Product] {$sku} Schema limit — retrying without '{$bloatingAttr}'");
+                unset($product['custom_attributes'][$bloatingAttr]);
+            }
+
+            if ($errorCode !== null) {
                 $this->logger->info("[Product] $sku Error: Code '" . $errorCode . "', Message '" . $errorMessage . "'");
                 $this->woowupStats['failed'][] = $product;
             }
@@ -82,7 +92,7 @@ class WoowUpProductUploader implements StageInterface
         }
 
         return $processedProducts;
-	}
+    }
 
     public function logProductData($product)
     {
@@ -97,25 +107,47 @@ class WoowUpProductUploader implements StageInterface
         $this->logger->info(json_encode($productData,JSON_PRETTY_PRINT));
     }
 
-	public function getWoowupStats()
-	{
-		return $this->woowupStats;
-	}
+    public function getWoowupStats()
+    {
+        return $this->woowupStats;
+    }
 
-	public function resetWoowupStats()
-	{
-		$this->woowupStats = [
-			'created' => 0,
-	        'updated' => 0,
-	        'failed'  => [],
-		];
+    public function resetWoowupStats()
+    {
+        $this->woowupStats = [
+            'created' => 0,
+            'updated' => 0,
+            'failed'  => [],
+        ];
 
-		return $this;
-	}
+        return $this;
+    }
 
     public function setWoowUpStats($woowupStats)
     {
         $this->woowupStats = $woowupStats;
+    }
+
+    private function extractBloatingAttribute(string $errorMessage, array $existingAttrNames = []): ?string
+    {
+        if (strpos($errorMessage, 'extended attribute definition very long') === false) {
+            return null;
+        }
+        $separatorPos = strpos($errorMessage, ' :: ');
+        if ($separatorPos === false) {
+            return null;
+        }
+        $data = json_decode(substr($errorMessage, $separatorPos + 4), true);
+        foreach ($data['checkbox_breakdown'] ?? [] as $entry) {
+            $name = $entry['name'] ?? null;
+            if ($name === null) {
+                continue;
+            }
+            if (empty($existingAttrNames) || in_array($name, $existingAttrNames, true)) {
+                return $name;
+            }
+        }
+        return null;
     }
 
     public function retryFailed()


### PR DESCRIPTION
### Problema

Cuando WoowUp rechaza el upsert de un producto con `bad_request` / `extended attribute definition very long` (el schema de atributos checkbox de la cuenta supera el límite de 65.535 bytes del TEXT column en MySQL), `WoowUpProductUploader` y `WoowUpHistoricalProductUploader` logueaban el error y descartaban el producto sin reintentar. Esto causaba que todos los productos de cuentas con schema lleno fallaran silenciosamente en cada sync.

El error de la API incluye un campo `checkbox_breakdown` que lista los atributos ordenados por cantidad de opciones almacenadas en WoowUp (no por lo que el producto está intentando agregar). Un intento anterior de fix en `woowup/connectors` usaba siempre el `[0]` del breakdown, lo que hacía que el loop cortara después del primer strip: al reintentar, el error seguía mostrando el mismo atributo como `[0]` (porque es el más grande en el schema guardado), pero ya había sido removido del producto → break prematuro, nunca llegaba al siguiente atributo bloating.

### Solución

- Ambos uploaders reciben un loop de retry de hasta 5 intentos. En cada fallo se parsea el `checkbox_breakdown` del error, se busca el primer atributo que **todavía esté presente** en el `custom_attributes` del producto, se stripea del payload y se reintenta.
- Se agrega el método privado `extractBloatingAttribute(string $errorMessage, array $existingAttrNames): ?string` en ambas clases, que itera el breakdown completo y saltea los atributos ya stripeados.
- Errores no relacionados con schema size (red, 404, internal_error) no entran al retry loop.

### Archivos modificados

- `src/Stages/Products/WoowUpProductUploader.php`
- `src/Stages/HistoricalProducts/WoowUpHistoricalProductUploader.php`
