### PR TITLE
fix(carts): sanitize customer email on abandoned cart upload

### DIFF
--- a/src/Stages/Carts/WoowUpCartUploader.php
+++ b/src/Stages/Carts/WoowUpCartUploader.php
@@ -70,7 +70,7 @@ class WoowUpCartUploader implements StageInterface
         try {
             if (!$this->woowupV2Client->users->exist($identity)) {
                 $customer = new UserModel();
-                $customer->setEmail($customerData['email']);
+                $customer->setEmail($customerData['email'], true);
                 if (!empty($customerData['first_name'])) {
                     $customer->setFirstName($customerData['first_name']);
                 }


### PR DESCRIPTION
## Descripción

Al crear el customer asociado a un carrito abandonado, el email se seteaba sin sanitización (`setEmail($email)` — `UserModel` tiene `sanitize=false` por default). Esto causaba que emails en mayúsculas o con typos (ej. `JUAN@GMAIL.COM`, `juan@gamil.com`) se enviaran a la API sin normalizar.

`AbandonedCartModel.setEmail` ya tenía `sanitize=true` por default, por lo que el email del carrito en sí no tenía este problema. Solo el email del customer.

## Cambio

`WoowUpCartUploader.php` línea 73: se agrega `true` al `setEmail` del customer para activar la sanitización del cleanser (normalización a minúsculas, corrección de typos de dominio).

## Validación

- Trazado completo del flow: `VTEXAbandonedCartsWorker` → `VTEXWoowUpCartMapper` → `WoowUpCartUploader` → `woowup-php-client-v2`
- Confirmado que `AbandonedCartModel.setEmail` ya sanitizaba por default (sin cambios necesarios)
- Comportamiento del cleanser validado localmente con casos borde (mayúsculas, typos de Gmail, emails cortos)
- Tests unitarios del cliente v2 validados