### PR TITLE
fix(customers): make date_from inclusive in Master Data where clause

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -554,10 +554,16 @@ class VTEXConnector
 
         $this->_logger->info("Getting customers by $dateField from $fromDate to $toDate and dataEntity $dataEntity" . ($startPage > 1 ? " (starting from page $startPage)" : ""));
 
+        // Master Data evaluates date comparisons at day granularity and strictly:
+        // a profile created at 2026-05-26T20:05Z does NOT match createdIn>2026-05-26.
+        // Shift the lower bound back one day so $fromDate is inclusive; otherwise
+        // profiles created/updated on $fromDate itself are silently skipped.
+        $exclusiveFrom = date('Y-m-d', strtotime($fromDate . ' -1 day'));
+
         if ($dateField === 'createdIn') {
-            $where = "(createdIn<$toDate) AND (createdIn>$fromDate)";
+            $where = "(createdIn<$toDate) AND (createdIn>$exclusiveFrom)";
         } else {
-            $where = "((updatedIn<$toDate) AND (updatedIn>$fromDate)) OR ((updatedIn is null) AND (createdIn<$toDate) AND (createdIn>$fromDate))";
+            $where = "((updatedIn<$toDate) AND (updatedIn>$exclusiveFrom)) OR ((updatedIn is null) AND (createdIn<$toDate) AND (createdIn>$exclusiveFrom))";
         }
 
         $params = [


### PR DESCRIPTION
## Problema

Master Data evalúa las comparaciones de fecha del `_where` **a granularidad de día y en forma estricta**: un perfil creado el `2026-05-26T20:05Z` NO matchea `createdIn>2026-05-26`. Como Airflow corre `vtex:customers` cada 6 horas con `days_from: 1` (`fromDate = ayer`), todo perfil creado/actualizado **después de la última corrida del día (18:15 UTC)** que no vuelve a modificarse **no se importa nunca**: las corridas del día siguiente usan `from = ese día` y la comparación estricta lo excluye para siempre.

**Dead zone diaria: 18:15→24:00 UTC (~24% del día), en todas las cuentas VTEX.** Caso reportado: Freeport (1490), 10 usuarios registrados en VTEX que nunca llegaron a WoowUp (los compradores entran igual por orders/carts, por eso solo se notó en perfiles "solo registro").

## Fix

Correr el límite inferior del `_where` un día hacia atrás para que `date_from` sea **inclusivo**. Un solo punto (`getCustomers()`), cubre los 3 caminos: `--days`, `--date_from` y `--historical`.

## Causa raíz — prueba directa contra Master Data

Perfil real del caso (creado `2026-05-26T20:05:13Z`, `updatedIn: null`). Mismo curl, solo cambia el límite de fecha:

```bash
# NO matchea su propio día de creación → []
curl -s "https://freeportstore.vtexcommercestable.com.br/api/dataentities/CL/search?_fields=id,email,createdIn,updatedIn&_where=(email=freedystoreshoes@outlook.com)%20AND%20(createdIn%3E2026-05-26)" \
  -H "Accept: application/vnd.vtex.ds.v10+json" -H "X-VTEX-API-AppKey: {APP_KEY}" -H "X-VTEX-API-AppToken: {APP_TOKEN}"
# → []

# Un día antes → matchea
curl -s "...&_where=(email=freedystoreshoes@outlook.com)%20AND%20(createdIn%3E2026-05-25)" ...
# → [{"id":"2b94fc00-b5d8-45d6-94f6-d5afa9f6c823","email":"freedystoreshoes@outlook.com","createdIn":"2026-05-26T20:05:13.8221199Z","updatedIn":null}]
```

El `_where` completo que arma `getCustomers()` para una corrida con `from=2026-05-26` (incluido el fallback `updatedIn is null`) también devuelve `[]` para este perfil:

```bash
curl -s "...&_where=(email=freedystoreshoes@outlook.com)%20AND%20(((updatedIn%3C2026-05-29)%20AND%20(updatedIn%3E2026-05-26))%20OR%20((updatedIn%20is%20null)%20AND%20(createdIn%3C2026-05-29)%20AND%20(createdIn%3E2026-05-26)))" ...
# → []   ← por esto el diario nunca lo importó
```

## Ejemplo real completo

Documento crudo en Master Data (`GET /api/dataentities/CL/documents/2b94fc00-b5d8-45d6-94f6-d5afa9f6c823?_fields=_all`):

```json
{
    "document": null,
    "gender": null,
    "GrupoOD": null,
    "GrupoOD2": null,
    "GrupoOD3": null,
    "profilePicture": null,
    "isCorporate": null,
    "tradeName": null,
    "rclastcart": null,
    "rclastcartvalue": null,
    "rclastsession": null,
    "rclastsessiondate": null,
    "homePhone": null,
    "phone": null,
    "brandPurchasedTag": null,
    "brandVisitedTag": null,
    "categoryPurchasedTag": null,
    "categoryVisitedTag": null,
    "departmentVisitedTag": null,
    "productPurchasedTag": null,
    "productVisitedTag": null,
    "stateRegistration": null,
    "email": "freedystoreshoes@outlook.com",
    "userId": "2a6d655c-b068-4a72-9396-06f02fd9d9c2",
    "firstName": null,
    "lastName": null,
    "isNewsletterOptIn": false,
    "localeDefault": null,
    "attach": null,
    "approved": null,
    "birthDate": null,
    "businessPhone": null,
    "carttag": null,
    "checkouttag": null,
    "corporateDocument": null,
    "corporateName": null,
    "documentType": null,
    "visitedProductWithStockOutSkusTag": null,
    "customerClass": null,
    "priceTables": null,
    "birthDateMonth": null,
    "restrictions": null,
    "tradePolicy": null,
    "id": "2b94fc00-b5d8-45d6-94f6-d5afa9f6c823",
    "accountId": "e2f275b0-cd82-4e37-ace0-73c1566d3c1b",
    "accountName": "freeportstore",
    "dataEntityId": "CL",
    "createdBy": "07c42932-51e3-4e75-98a3-941861356230",
    "createdIn": "2026-05-26T20:05:13.8221199Z",
    "updatedBy": null,
    "updatedIn": null,
    "lastInteractionBy": "07c42932-51e3-4e75-98a3-941861356230",
    "lastInteractionIn": "2026-05-26T20:05:13.8221226Z",
    "followers": [],
    "tags": [],
    "auto_filter": null
}
```

En WoowUp:

```bash
curl -s -o /dev/null -w "%{http_code}" "https://api.woowup.com/apiv3/multiusers/find?email=freedystoreshoes@outlook.com" \
  -H "Authorization: Basic {WOOWUP_APIKEY_1490}"
# → 404
```

Los 10 reportados (todos `updatedIn: null`, todos 404 en WoowUp, todos en la dead zone):

| email | createdIn (UTC) |
|---|---|
| freedystoreshoes@outlook.com | 2026-05-26 20:05 |
| freedomfreeportzapato@hotmail.com | 2026-05-26 20:11 |
| danielzapatazapata@outlook.es | 2026-05-26 20:14 |
| campercolombiafreeport@outlook.es | 2026-05-26 20:19 |
| florsheinzapatosco@hotmail.com | 2026-05-26 20:24 |
| converseconfreeport@hotmail.com | 2026-05-26 20:27 |
| edwinfreeportfreeman@gmail.com | 2026-05-27 20:41 |
| lauriss.nivia@gmail.com | 2026-05-27 20:52 |
| ojodebrujaa@gmail.com | 2026-05-27 20:55 |
| whytchyangelik@gmail.com | 2026-05-27 20:58 |

Control: vecinos creados los mismos días **antes** de las 18:15 UTC (13:03, 16:58) están en WoowUp con la firma del diario (tag `VTEX` + attrs `opt_in_vtex`/`created_in`). Los de después de 18:15 que sí figuran entraron por carritos o CSV — ninguno tiene la firma del diario.

## Pruebas del fix (A/B, Freeport 1490)

Misma ventana `--date_from=2026-05-25 --date_to=2026-05-28`, corridas locales en `--read-only`/`-D` (sin escribir):

| | Pre-fix | Post-fix |
|---|---|---|
| Límite inferior efectivo | `>2026-05-25` | `>2026-05-24` |
| **Total customers (scroll)** | **290** | **421** (+131 del 25/5, antes excluidos) |
| 10 reportados en el log | 10/10\* | 10/10 |
| Errores | 0 | 0 |

\* pre-fix aparecen solo porque `from=05-25` no es su día de creación; con el `from` del diario (`= día de creación`) quedan en `[]`, como muestra el curl de arriba.

Verificación cruzada: reproduciendo el scroll a mano (curl paginado con `X-VTEX-MD-TOKEN`) con el límite ya corrido → exactamente 421 IDs, los 10 incluidos. El código post-fix produce el mismo universo que la query corregida a mano.

Payload que el pipeline arma para el perfil del ejemplo (post-fix, `DebugUploadStage` — antes del fix este perfil ni siquiera entraba al pipeline):

```json
{
    "email": "freedystoreshoes@outlook.com",
    "mailing_enabled": "disabled",
    "sms_enabled": "disabled",
    "mailing_enabled_reason": "other",
    "sms_enabled_reason": "other",
    "whatsapp_enabled": "disabled",
    "whatsapp_enabled_reason": "other",
    "custom_attributes": {
        "opt_in_vtex": "False",
        "created_in": "2026-05-26 20:05:13"
    }
}
```

## Riesgo

Bajo: 3 líneas en un método, solo flujos de customers. El overlap de 1 día re-upsertea perfiles ya procesados — idempotente (uploader es create-or-update) y el mapeo de opt-in ya preserva valores gestionados fuera del conector (`newComunicationOptIn`). Impacta recién al bumpear el hash en connectors; rollback = revertir el bump.
