### PR TITLE
fix(carts): use public store domain for abandoned cart recover URL

### DIFF
--- a/src/Stages/Carts/VTEXWoowUpCartMapper.php
+++ b/src/Stages/Carts/VTEXWoowUpCartMapper.php
@@ -123,6 +123,10 @@ class VTEXWoowUpCartMapper implements StageInterface
         if (strpos($url, 'http') === 0) {
             return $url;
         }
+        $storeUrl = $this->vtexConnector->getStoreUrl();
+        if ($storeUrl) {
+            return rtrim($storeUrl, '/') . '/checkout/cart/' . $url;
+        }
         $accountName = $cartdata['accountName'] ?? null;
         if (!$accountName) {
             return $url;


### PR DESCRIPTION
## Qué

En el mapper de carritos abandonados (`VTEXWoowUpCartMapper::buildRecoverUrl`), la URL de recuperación se arma ahora con el **dominio público de la tienda** (`storeUrl`) en lugar del dominio interno de VTEX (`{accountName}.vtexcommercestable.com.br`).

## Por qué

El recover URL apuntaba al dominio interno `vtexcommercestable.com.br`, que no es la storefront real que ve el cliente. Usando `getStoreUrl()` (mismo patrón que `VTEXWoowUpOrderMapper` y los mappers de productos) el link lleva al checkout del dominio público correcto.

## Cómo

- Si `rclastcart` ya es una URL absoluta (`http...`), se devuelve tal cual (sin cambios).
- Si hay `storeUrl` configurado en la cuenta → `{storeUrl}/checkout/cart/{rclastcart}`.
- Fallback al comportamiento anterior (`{accountName}.vtexcommercestable.com.br`) solo si la cuenta no tiene `storeUrl`.