### PR TITLE
fix(products): retry on VTEX 400 catalog search SQL timeout

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -1115,7 +1115,7 @@ class VTEXConnector
                     } elseif ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
                         // VTEX returns 400 for transient SQL Server timeouts on catalog search
                         if (strpos($message, "Can't create search criteria!") !== false) {
-                            $this->_logger->info("VTEX transient timeout on 400, retrying. endpoint: " . $endpoint);
+                            $this->_logger->error("VTEX transient timeout on 400, retrying. endpoint: " . $endpoint);
                         } else {
                             throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
                         }

--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -1113,7 +1113,12 @@ class VTEXConnector
                         $retryAfter = (int)($response->getHeader('Retry-After')[0] ?? 0);
                         sleep($retryAfter > 0 ? $retryAfter : self::TOO_MANY_REQUESTS_SLEEP_SEC);
                     } elseif ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
-                        throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
+                        // VTEX returns 400 for transient SQL Server timeouts on catalog search
+                        if (strpos($message, "Can't create search criteria!") !== false) {
+                            $this->_logger->info("VTEX transient timeout on 400, retrying. endpoint: " . $endpoint);
+                        } else {
+                            throw new VTEXRequestException($message, $code, $endpoint, $queryParams);
+                        }
                     } elseif (in_array($response->getStatusCode(), [500, 502, 503, 504])) {
                         $text = is_string($decoded) ? $decoded : $body;
                         if (strpos($text, 'não encontrado') !== false) {


### PR DESCRIPTION
## Problema

Al sincronizar productos de VTEX, el endpoint `/api/catalog_system/pub/products/search` a veces devuelve un **HTTP 400** con el siguiente mensaje:

```
Can't create search criteria! Error:Connection Timeout Expired. The timeout period elapsed
while attempting to consume the pre-login handshake acknowledgement. This could be because
the pre-login handshake failed or the server was unable to respond back in time.
```

Este error no es un problema del request sino un timeout interno de la infraestructura de VTEX (su SQL Server no respondió a tiempo). Sin embargo, al ser un 4xx, el cliente lo trataba como un error de cliente y lanzaba la excepción inmediatamente sin reintentar, fallando la sincronización completa de la cuenta.

## Solución

En `_request()`, antes de lanzar la excepción por un error 4xx, se verifica si el mensaje contiene `"Can't create search criteria!"`. Si es así, se trata como un error transitorio y se deja continuar el loop de reintentos con el backoff exponencial existente (hasta 25 intentos, máximo 60s entre cada uno), en lugar de fallar de inmediato.

Todos los demás errores 4xx siguen fallando inmediatamente como antes.
