### PR TITLE
fix(products): resolve sales channel with priority config > backend > default 1

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -25,6 +25,11 @@ class VTEXConnector
     const HISTORICAL_PRODUCTS_SEARCH_LIMIT =  500;
     const PRODUCTS_MAX_VALUE_FROM_PARAMETER = 2500;
 
+    // Default sales channel for product searches. The authenticated Search API without `sc`
+    // returns only the intersection of all channels (a cropped catalog), so we default to the
+    // main channel (1) when the account does not set `products_sales_channel` in its config.
+    const DEFAULT_PRODUCTS_SALES_CHANNEL = 1;
+
     const INVALID_VTEX_MAIL = 'ct.vtex.com.br';
     const DEFAULT_BRANCH_NAME = 'VTEX';
 
@@ -88,6 +93,8 @@ class VTEXConnector
     private $_allowedSellers;
     private $_syncCategories;
     private $_salesChannel;
+    private $_salesChannelId;
+    private $_salesChannelList;
 
     private $_categories;
 
@@ -118,6 +125,9 @@ class VTEXConnector
             $this->_httpClient     = $httpClient;
             $this->features        = $features;
             $this->_salesChannel   = isset($vtexConfig['salesChannel']) ? $this->getSalesChannel($vtexConfig['salesChannel']) : null;
+            // Raw backend sales channel id (before name conversion). Used as the products `sc`
+            // fallback, since the catalog Search API expects the numeric channel id, not its name.
+            $this->_salesChannelId = $vtexConfig['salesChannel'] ?? null;
             $this->accountConfig   = $accountConfig;
         } catch (\Exception $e) {
             $this->_logger->error("VTEX Service Error: " . $e->getMessage());
@@ -139,21 +149,92 @@ class VTEXConnector
     private function getSalesChannel($salesChannelFromConfig)
     {
         if (filter_var($salesChannelFromConfig, FILTER_VALIDATE_INT) !== false) {
-            try {
-                $response = $this->_get('/api/catalog_system/pvt/saleschannel/list');
-                $body = json_decode($response->getBody(), true);
-
-                // Search for the matching sales channel by ID
-                foreach ($body as $salesChannel) {
-                    if ($salesChannel['Id'] == $salesChannelFromConfig) {
-                        return $salesChannel['Name'];
-                    }
+            // Search for the matching sales channel by ID
+            foreach ($this->getSalesChannelList() as $salesChannel) {
+                if ($salesChannel['Id'] == $salesChannelFromConfig) {
+                    return $salesChannel['Name'];
                 }
-            } catch (\Exception $e) {
-                $this->_logger->error("VTEX Error retrieving sales channel list: " . $e->getMessage());
             }
         }
         return $salesChannelFromConfig;
+    }
+
+    /**
+     * Fetches the account's sales channel list once and caches it for the rest of the run.
+     *
+     * @return array list of sales channels ([{Id, Name, IsActive, ...}]); empty array on error
+     */
+    private function getSalesChannelList()
+    {
+        if ($this->_salesChannelList === null) {
+            try {
+                $response = $this->_get('/api/catalog_system/pvt/saleschannel/list');
+                $this->_salesChannelList = json_decode($response->getBody(), true) ?: [];
+            } catch (\Exception $e) {
+                $this->_logger->error("VTEX Error retrieving sales channel list: " . $e->getMessage());
+                $this->_salesChannelList = [];
+            }
+        }
+        return $this->_salesChannelList;
+    }
+
+    /**
+     * Resolves the backend integration sales channel ("cajita") to its numeric id, since the
+     * field may hold either a numeric id (e.g. "4") or a channel name (e.g. "Main"), while the
+     * catalog Search API expects the numeric id.
+     *
+     * @return int|null the numeric sales channel id, or null if unset/empty/unresolvable
+     */
+    private function resolveBackendSalesChannelId()
+    {
+        $raw = $this->_salesChannelId;
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        if (filter_var($raw, FILTER_VALIDATE_INT) > 0) {
+            return (int) $raw;
+        }
+
+        // It's a name (e.g. "Main") -> look up its id in the sales channel list
+        foreach ($this->getSalesChannelList() as $salesChannel) {
+            if (isset($salesChannel['Name']) && strcasecmp($salesChannel['Name'], $raw) === 0) {
+                return $salesChannel['Id'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the sales channel id to use for product (catalog) searches, with priority:
+     *   1. products_sales_channel from the account config (config/vtex.php).
+     *   2. the backend integration sales channel ("cajita"), resolved to its numeric id
+     *      (the field may hold either an id like "4" or a name like "Main").
+     *   3. the default channel (1).
+     *
+     * The authenticated Search API without `sc` returns only the intersection of all channels
+     * (a cropped catalog), so a channel is always resolved.
+     *
+     * @param string $context label used only for logging which search is resolving the channel
+     * @return int|string the sales channel id to send as `sc`
+     */
+    private function resolveProductsSalesChannel($context)
+    {
+        $configuredSalesChannel = $this->accountConfig['products_sales_channel'] ?? null;
+        if ($configuredSalesChannel !== null) {
+            $this->_logger->info("Using configured sales channel: $configuredSalesChannel for $context");
+            return $configuredSalesChannel;
+        }
+
+        $backendSalesChannelId = $this->resolveBackendSalesChannelId();
+        if ($backendSalesChannelId !== null) {
+            $this->_logger->info("No products_sales_channel configured, using backend sales channel: {$this->_salesChannelId} (id $backendSalesChannelId) for $context");
+            return $backendSalesChannelId;
+        }
+
+        $this->_logger->info("No sales channel configured, using default: " . self::DEFAULT_PRODUCTS_SALES_CHANNEL . " for $context");
+        return self::DEFAULT_PRODUCTS_SALES_CHANNEL;
     }
 
     /**
@@ -336,10 +417,7 @@ class VTEXConnector
 
         $totalProductsRetrieved = 0;
 
-        $salesChannel = $this->accountConfig['products_sales_channel'] ?? null;
-        if ($salesChannel) {
-            $this->_logger->info("Using sales channel: $salesChannel for products search");
-        }
+        $salesChannel = $this->resolveProductsSalesChannel('products search');
 
         $this->_logger->info("Getting category leaves");
         $categoryLeaves = $this->getCategoryLeaves(['children' => $categoryTree, 'id' => '']);
@@ -414,7 +492,7 @@ class VTEXConnector
             $this->populateCategories();
 
             $params = ['fq' => "skuId:$skuId"];
-            $salesChannel = $this->accountConfig['products_sales_channel'] ?? null;
+            $salesChannel = $this->resolveProductsSalesChannel('single product search');
             if ($salesChannel) {
                 $params['sc'] = $salesChannel;
             }
@@ -444,6 +522,10 @@ class VTEXConnector
 
     protected function getSkuIdList()
     {
+        // Historical SKU list intentionally does NOT use resolveProductsSalesChannel(): it only
+        // filters by channel when the account has an explicit products_sales_channel in config,
+        // otherwise it keeps pulling every SKU (all channels), as before. Narrowing the historical
+        // load to a single resolved/default channel is pending review (see PR discussion).
         $salesChannel = $this->accountConfig['products_sales_channel'] ?? null;
 
         $endpoint = $salesChannel


### PR DESCRIPTION
## Problema

La Search API autenticada de VTEX (AppKey/AppToken) **sin el parámetro `sc`** no devuelve el catálogo completo: devuelve solo la **intersección de todos los canales de venta** (un catálogo recortado). Las cuentas que no tenían un sales channel definido venían sincronizando un catálogo incompleto de forma silenciosa.

Caso testigo: **Shop Gallery (1437)**, SKU 428721 (Monteagrelo Malbec). Ni el diario ni el worker del webhook lo veían porque quedaba fuera de la intersección (45 de 375 vinos). Con `sc=1` el catálogo pasó de **566 → 7.963 productos mapeados (14×)**.

## Cambio

Las búsquedas de productos del **diario** (`getProducts`) y del **worker de webhook** (`getSingleProduct`) ahora resuelven el `sc` con un orden de prioridad claro, centralizado en `resolveProductsSalesChannel()`:

1. **`products_sales_channel`** del config de la cuenta (`config/vtex.php`) → si está, gana.
2. **sales channel de la integración del backend** (la "cajita", campo `sales_channel`). Lo carga a mano quien da de alta la integración, así que puede venir como **ID numérico** (`"4"`) o como **nombre de canal** (`"Main"`):
   - ID numérico → se usa directo.
   - nombre → se resuelve a su ID contra `/saleschannel/list` (cacheada por corrida, no pega por cada SKU).
3. **default `1`** (canal principal) → si la cajita está vacía o el nombre no existe.

> Detalle técnico: órdenes usan el **nombre** del canal (`f_salesChannel`), pero el catálogo usa el **ID numérico** (`sc`). Por eso se guarda el valor crudo de la cajita (`_salesChannelId`) y se resuelve a ID solo para productos.

### Histórico (getSkuIdList): sin cambios a propósito

El histórico **NO** usa `resolveProductsSalesChannel()`. Sigue como antes: filtra por canal **solo si la cuenta tiene `products_sales_channel` explícito en config**; si no, trae **todos los SKUs** (todos los canales). Esto evita achicar la cobertura histórica de las cuentas que hoy cargan el catálogo completo. _(Unificar el histórico al mismo canal resuelto que el diario quedó como revisión pendiente, a evaluar aparte.)_

La lógica de órdenes/clientes (`f_salesChannel`) **no se toca**.

## Por qué la resolución nombre→ID es necesaria

Muestreo real del campo `sales_channel` en el backend (17 cuentas): es **mixto**.
- ID numérico: Freekick (`"4"`), Wine Concierge (`"2"`), ColeHaan (`"6"`), Dyson (`"3"`).
- **Nombre**: Sportotal (`"Main"`), Freeport (`"Principal"`), **Brissa (`"almacenes brissa"`)**.
- null / vacío: la mayoría.

Brissa (1361) no tiene `products_sales_channel` en config y su cajita es un **nombre** → sin resolución, caería al default 1 silenciosamente.

## Observabilidad

Logs que distinguen el **origen** del canal (diario / single product):
- `Using configured sales channel: X ...` → vino de `config/vtex.php`.
- `No products_sales_channel configured, using backend sales channel: <raw> (id N) ...` → vino de la cajita (con el ID resuelto).
- `No sales channel configured, using default: 1 ...` → cayó al default.

El histórico mantiene su log original `Filtering historical products by sales channel: X` (solo cuando hay config explícito).

## Validación

**En vivo contra la API real:**

| Cuenta | Fuente | Log | Resultado |
|--------|--------|-----|-----------|
| Freekick (1857) | config `=4` | `Using configured sales channel: 4` | ✅ |
| Brissa (1361) | cajita = `"almacenes brissa"` (nombre) | `using backend sales channel: almacenes brissa (id 1)` | ✅ resuelto a su ID real (1) |
| Shop Gallery (1437) | cajita vacía | `No sales channel configured, using default: 1` | ✅ + catálogo completo (paginó hasta `_from` 675) |

**Test determinístico (reflexión, offline, lista de canales ficticia):** 10/10 OK
- config gana sobre la cajita
- cajita ID (int `5` / string `"5"`) → directo
- cajita nombre → resuelto al ID que diga la lista, incl. un caso ID≠1 y match case-insensitive
- cajita inexistente / null / `""` / `0` → default 1

**Review independiente del diff:** sin regresiones en `getSalesChannel` (órdenes), orden de constructor OK, tipos `sc` OK.

## Riesgo / blast radius

Afecta a **todas** las cuentas VTEX (el diario y el worker del webhook). Distribución actual:
- **~7 cuentas con `products_sales_channel` en config** (Sportotal=1, Freekick=4, ColeHaan=6, Yichang=1, Dyson=3, Wine Concierge=2, Merrell=7) → **mantienen su valor**, sin cambios.
- **El resto** pasa de "sin `sc`" (catálogo recortado) a: su cajita del backend resuelta a ID, o `sc=1` si no tiene. Esto **corrige el bug latente en masa**.
- Riesgo residual: una cuenta cuyo storefront real esté en un canal distinto al que termina resolviendo (cajita mal cargada o ausente y canal principal ≠ 1). Conviene relevar con un script contra `/saleschannel/list` las cuentas con 2+ canales activos. Los logs de observabilidad permiten auditar qué resolvió cada cuenta.

## Notas

- Si falla el fetch de `/saleschannel/list`, una cajita con **nombre** degrada a default `1` esa corrida (degradación segura). Hoy se cachea `[]` y no reintenta en la misma corrida.

## Deploy

Requiere `composer update woowup/vtex-woowup-connector` en el repo `connectors` para arrastrar el cambio.
