### PR TITLE
fix(customers): log scroll token restart at error level and catch warmup failures

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -626,19 +626,24 @@ class VTEXConnector
                         && $tokenRestarts < self::SCROLL_TOKEN_RESTART_LIMIT
                     ) {
                         $tokenRestarts++;
-                        $this->_logger->warning("VTEX scroll token expired on page $page (restart $tokenRestarts/" . self::SCROLL_TOKEN_RESTART_LIMIT . "), fast-forwarding to refresh cursor...");
+                        $this->_logger->error("VTEX scroll token expired on page $page (restart $tokenRestarts/" . self::SCROLL_TOKEN_RESTART_LIMIT . "), fast-forwarding to refresh cursor...");
                         unset($params['_token']);
-                        for ($warmup = 1; $warmup < $page; $warmup++) {
-                            $warmupResponse = $this->_getCustomersWithRetry('/api/dataentities/' . $dataEntity . '/scroll', $params, $requestHeaders, $warmup);
-                            $warmupToken = $warmupResponse->getHeader('X-VTEX-MD-TOKEN');
-                            if (!empty($warmupToken)) {
-                                $params['_token'] = $warmupToken[0];
-                            } else {
-                                unset($params['_token']);
+                        try {
+                            for ($warmup = 1; $warmup < $page; $warmup++) {
+                                $warmupResponse = $this->_getCustomersWithRetry('/api/dataentities/' . $dataEntity . '/scroll', $params, $requestHeaders, $warmup);
+                                $warmupToken = $warmupResponse->getHeader('X-VTEX-MD-TOKEN');
+                                if (!empty($warmupToken)) {
+                                    $params['_token'] = $warmupToken[0];
+                                } else {
+                                    unset($params['_token']);
+                                }
+                                $this->_logger->error("Token refresh fast-forward: page $warmup / " . ($page - 1));
                             }
-                            $this->_logger->info("Token refresh fast-forward: page $warmup / " . ($page - 1));
+                            $this->_logger->error("Token refreshed, retrying page $page");
+                        } catch (\Exception $warmupEx) {
+                            $this->_logger->error("Token refresh fast-forward failed on warmup: " . $warmupEx->getMessage() . ". Aborting restart.");
+                            throw $e;
                         }
-                        $this->_logger->info("Token refreshed, retrying page $page");
                     } else {
                         throw $e;
                     }


### PR DESCRIPTION
## Problema

Cuando el token del scroll de clientes (`/api/dataentities/CL/scroll`) expiraba por
sincronizaciones largas, el mecanismo de restart (fast-forward del cursor) existía pero tenía
dos problemas:

1. Los logs del restart usaban `warning()` e `info()`, niveles que no aparecen en la salida de
   Airflow, por lo que era imposible saber si el restart se había intentado o no.
2. Si alguna de las llamadas de warmup fallaba durante el fast-forward, la excepción propagaba
   sin ser atrapada ni logueada, haciendo que el proceso muriera silenciosamente sin diagnóstico.

## Solución

Todos los logs del restart pasaron a `error()` para garantizar su visibilidad en Airflow.
El loop de warmup ahora está envuelto en `try/catch`: si una llamada falla, se logea el error
específico antes de relanzar la excepción original.