### PR TITLE
fix(products): retry catalog search without sc when VTEX rejects the channel

### DIFF
--- a/src/VTEXConnector.php
+++ b/src/VTEXConnector.php
@@ -95,6 +95,7 @@ class VTEXConnector
     private $_salesChannel;
     private $_salesChannelId;
     private $_salesChannelList;
+    private $_skipProductsSalesChannel = false;
 
     private $_categories;
 
@@ -235,6 +236,59 @@ class VTEXConnector
 
         $this->_logger->info("No sales channel configured, using default: " . self::DEFAULT_PRODUCTS_SALES_CHANNEL . " for $context");
         return self::DEFAULT_PRODUCTS_SALES_CHANNEL;
+    }
+
+    /**
+     * Runs a catalog products search, dropping the `sc` (sales channel) filter and retrying once
+     * if VTEX rejects the resolved channel for this account.
+     *
+     * Some accounts (typically B2B tenants) reject the configured `sc` with HTTP 401
+     * "sc N is not available for account ..." (or 400 "sc is inactive") even when the channel is
+     * listed as active in /saleschannel/list, because the catalog host is bound to a different
+     * channel. Failing the whole products run over this is worse than fetching the catalog without
+     * the channel filter, so we drop `sc`, retry, and skip it for the rest of the run (the flag
+     * avoids paying a double request on every category leaf once we know it's rejected).
+     *
+     * @param  array $params query params for /api/catalog_system/pub/products/search (may include 'sc')
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    private function productsSearch(array $params)
+    {
+        if ($this->_skipProductsSalesChannel) {
+            unset($params['sc']);
+        }
+
+        try {
+            return $this->_get('/api/catalog_system/pub/products/search', $params);
+        } catch (\Exception $e) {
+            if (isset($params['sc']) && $this->isUnavailableSalesChannelError($e)) {
+                $this->_logger->warning("VTEX rejected sales channel {$params['sc']} ({$e->getMessage()}); retrying products search without sc for the rest of the run");
+                $this->_skipProductsSalesChannel = true;
+                unset($params['sc']);
+                return $this->_get('/api/catalog_system/pub/products/search', $params);
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Tells whether an exception from a products search is VTEX rejecting the requested sales
+     * channel (401 "sc N is not available ..." / 400 "sc is inactive"), as opposed to any other
+     * request error.
+     *
+     * @param  \Exception $e exception thrown by the catalog request
+     * @return bool true when the channel filter should be dropped and the search retried
+     */
+    private function isUnavailableSalesChannelError(\Exception $e)
+    {
+        $code = $e->getCode();
+        if ($code !== 401 && $code !== 400) {
+            return false;
+        }
+
+        $message = strtolower($e->getMessage());
+        return strpos($message, 'sc') !== false
+            && (strpos($message, 'not available') !== false || strpos($message, 'is inactive') !== false);
     }
 
     /**
@@ -430,7 +484,7 @@ class VTEXConnector
                 if ($salesChannel) {
                     $params['sc'] = $salesChannel;
                 }
-                $response = $this->_get('/api/catalog_system/pub/products/search', $params);
+                $response = $this->productsSearch($params);
 
                 if (($response->getStatusCode() !== 200) && ($response->getStatusCode() !== 206)) {
                     throw new \Exception($response->getReasonPhrase(), $response->getStatusCode());
@@ -453,7 +507,7 @@ class VTEXConnector
             if ($salesChannel) {
                 $params['sc'] = $salesChannel;
             }
-            $response = $this->_get('/api/catalog_system/pub/products/search', $params);
+            $response = $this->productsSearch($params);
 
             if (($response->getStatusCode() !== 200) && ($response->getStatusCode() !== 206)) {
                 throw new \Exception($response->getReasonPhrase(), $response->getStatusCode());
@@ -496,7 +550,7 @@ class VTEXConnector
             if ($salesChannel) {
                 $params['sc'] = $salesChannel;
             }
-            $response = $this->_get('/api/catalog_system/pub/products/search', $params);
+            $response = $this->productsSearch($params);
 
             if ($response->getStatusCode() !== 200) {
                 throw new \Exception($response->getReasonPhrase(), $response->getStatusCode());


### PR DESCRIPTION
## Problema

`vtex_products` falla la corrida **entera** para cuentas donde VTEX rechaza el sales channel resuelto.
Caso reportado: **raggedb2b (account_1692)**, DAG `vtex_products`:

```
VTEX 401 "sc 1 is not available for account raggedb2b"
```

## Causa raíz (verificada en vivo contra la API real de la cuenta)

- La cajita backend `sales_channel` de la integración está cargada en `'1'` → `resolveProductsSalesChannel()`
  resuelve `sc=1` para la búsqueda de productos.
- raggedb2b es un tenant **B2B**: el canal 1 ("Principal") **figura `IsActive=true` en `/saleschannel/list`**,
  pero el host del catálogo **no lo sirve** (está bindeado al canal 2 "B2B Ragged").
- `_get('/products/search')` recibe el 401 y lanza `VTEXRequestException` → la excepción propaga y **revienta
  toda la corrida** de productos (no es una cuenta puntual: cualquier tenant en esta situación cae igual).

Matriz de pruebas contra `https://raggedb2b.vtexcommercestable.com.br/api/catalog_system/pub/products/search`:

| `sc` | Resultado real |
|------|----------------|
| 1 (figura activo en la lista) | **401** `"sc 1 is not available for account raggedb2b"` |
| 2 ("B2B Ragged") | 206 OK — **1391 productos** |
| 3 (inactivo) | 400 `"sc is inactive"` |
| **sin `sc`** | 206 OK — **1391 productos** (idéntico a sc=2) |

`/saleschannel/list` de la cuenta:
```
Id=1 Name=Principal           IsActive=true
Id=2 Name=B2B Ragged          IsActive=true
Id=3 Name=Ragged Internacional IsActive=false
```

## Por qué esta decisión

Se evaluaron tres caminos:

1. **Config por cuenta (`products_sales_channel => 2` para 1692).** Resuelve el caso puntual pero:
   no es genérico (el próximo tenant B2B vuelve a romper), depende de cargar a mano el canal correcto,
   y queda frágil si VTEX cambia el binding. Descartado como solución de fondo.

2. **Validar el `sc` resuelto contra `/saleschannel/list` antes de usarlo.** **No funciona acá**: el canal 1
   aparece `IsActive=true` en la lista, así que esa validación lo daría por bueno y el 401 seguiría apareciendo.
   El "está disponible" del catálogo no coincide con el "está activo" de la lista para tenants B2B.

3. **Reintentar sin `sc` cuando VTEX rechaza el canal (elegida).** Es el único enfoque que:
   - es **genérico** — cualquier cuenta que pegue el mismo rechazo queda estabilizada sin tocar config;
   - es **seguro para esta cuenta** — sin `sc` devuelve exactamente los mismos 1391 productos que sc=2
     (no recorta catálogo, que era el motivo original por el que se forzaba un `sc` por defecto, PR #219);
   - **degrada en vez de fallar** — preferimos bajar el catálogo sin filtro de canal antes que tirar
     abajo toda la corrida de `vtex_products`.

## Fix

Nuevo helper `productsSearch(array $params)` que envuelve los **3 call sites** de `/products/search`
(`getProducts` ×2 + `getSingleProduct`):

- Hace el `_get` normal.
- Si VTEX rechaza el `sc` (401 `"... not available"` / 400 `"sc is inactive"`), loguea un warning,
  **dropea el filtro `sc` y reintenta una sola vez sin él**, y prende un flag `_skipProductsSalesChannel`
  para saltear `sc` el resto de la corrida (evita pagar el doble request en cada *category leaf*).
- Cualquier otro error de request se **re-lanza sin cambios** (no enmascara fallos reales).

No toca el histórico (`getSkuIdList`) ni el flujo de órdenes.

## Pruebas

Test offline con Guzzle `MockHandler` (Reflection, sin red) — **14/14**:

```
=== TEST 1: 401 'sc not available' -> retry sin sc ===
[PASS] devuelve 206 tras fallback
[PASS] body trae el producto
[PASS] flag _skipProductsSalesChannel quedo en true
[PASS] se hicieron 2 requests
[PASS] 1er request llevaba sc=1
[PASS] 2do request (retry) NO lleva sc

=== TEST 2: con flag ya prendido, salta sc desde el 1er request ===
[PASS] un solo request
[PASS] sin sc desde el arranque

=== TEST 3: error NO relacionado a sc (500) NO se traga ===
[PASS] matcher: 500 NO matchea

=== TEST 4: matcher casos varios ===
[PASS] matcher[0] code=401 msg='sc 1 is not available for account raggedb2b' => true
[PASS] matcher[1] code=400 msg='sc is inactive' => true
[PASS] matcher[2] code=401 msg='unauthorized' => false
[PASS] matcher[3] code=404 msg='sc 9 is not available' => false
[PASS] matcher[4] code=400 msg='something is not available' => false

=== 14 pasaron, 0 fallaron ===
```

Además, validación en vivo contra la API real de raggedb2b confirmó la matriz de arriba (sc=1 → 401,
sin sc → 206 con 1391 productos).

## Nota operativa

La cajita backend de 1692 quedó cargada en `'1'` (valor que no sirve para ese tenant). El fix **no depende**
de corregirla, pero conviene limpiarla a `2` o vacío del lado del alta de la integración.
