### PR TITLE
fix(orders): skip pickup store address when building customer from order

### DIFF
--- a/src/Stages/Orders/VTEXWoowUpOrderMapper.php
+++ b/src/Stages/Orders/VTEXWoowUpOrderMapper.php
@@ -14,6 +14,9 @@ class VTEXWoowUpOrderMapper implements StageInterface
     const DISABLED_REASON_OTHER  = 'other';
     const INVALID_EMAILS         = ['ct.vtex.com.br', 'mercadolibre.com'];
     const MAX_PERCENTAGE_BAD_CATALOGING_PRODUCTS = 5;
+    // En órdenes de retiro en tienda VTEX carga en shippingData.address la dirección del LOCAL
+    // (addressType 'pickup'), no la del cliente. Se usa para no persistir esa dirección en el perfil.
+    const ADDRESS_TYPE_PICKUP    = 'pickup';
 
     protected $importing;
     protected $notifier;
@@ -157,8 +160,15 @@ class VTEXWoowUpOrderMapper implements StageInterface
             }
         }
 
-        // Tomo datos de ubicación desde shippingData
-        if (isset($vtexOrder->shippingData) && isset($vtexOrder->shippingData->address) && !empty($vtexOrder->shippingData->address)) {
+        // Tomo datos de ubicación desde shippingData, salvo en órdenes de retiro en tienda:
+        // ahí VTEX carga la dirección del LOCAL (addressType 'pickup'), no la del cliente, y la
+        // persistiríamos pisando la dirección real del perfil. Solo mapeo la dirección cuando NO es
+        // un retiro (envíos traen la dirección real: addressType 'residential'/'commercial'/etc.).
+        if (
+            isset($vtexOrder->shippingData->address) &&
+            !empty($vtexOrder->shippingData->address) &&
+            (($vtexOrder->shippingData->address->addressType ?? null) !== self::ADDRESS_TYPE_PICKUP)
+        ) {
             $address = $vtexOrder->shippingData->address;
             $customer += [
                 'postcode' => $address->postalCode,
@@ -167,7 +177,7 @@ class VTEXWoowUpOrderMapper implements StageInterface
                 'country'  => $address->country,
                 'street'   => ucwords(mb_strtolower(trim(trim($address->street) . " " . trim($address->number)))),
             ];
-        }       
+        }
 
         return $customer;
     }


### PR DESCRIPTION
## Problema

En órdenes de **retiro en tienda**, VTEX carga en `shippingData.address` la dirección del **local de retiro** (con `addressType: "pickup"`), no la del cliente. `VTEXWoowUpOrderMapper::buildCustomerFromOrder` la persistía tal cual en el perfil del cliente → la dirección de la tienda terminaba pisando la dirección real (gana la última orden procesada).

Reportado por Customer Data en Mario Hernández (app_id 993).

## Fix

Solo se mapea la dirección cuando la orden **no** es un retiro. Los envíos (addressType `residential`/`commercial`/etc.) siguen actualizando el perfil; los pickups dejan de pisarlo.

Se eligió `addressType !== 'pickup'` (saltear solo el retiro explícito) en lugar de `=== 'residential'`: este es el mapper base de **todas** las cuentas VTEX, y un `=== 'residential'` descartaría envíos comerciales legítimos. Así el cambio de comportamiento aplica **únicamente** a órdenes de retiro; todo lo demás (residential, commercial, o addressType ausente) queda igual que antes.

## Validación

- Cross-tab de 49 órdenes reales de un cliente (993): `addressType` es señal 100% confiable — **36/36** envíos → `residential` (dirección real), **13/13** retiros → `pickup` (dirección del local). Cruzado contra la sla elegida (`selectedSla`), coincide sin excepciones.
- Test offline (9 casos): pickup → no setea dirección y conserva identidad; residential/commercial/addressType-ausente → sí setea; sin `shippingData.address` → no rompe.
- `php -l` OK.

## Notas

- Fix **preventivo**: evita que futuras órdenes de retiro corrompan el perfil. No reescribe perfiles ya afectados (se corrigen solos en la próxima orden de envío del cliente).
- Tras mergear: bump del hash de `woowup/vtex-woowup-connector` en `connectors` (composer).